### PR TITLE
Remove strapi-plugin-import-export-entries

### DIFF
--- a/cockpit-api/.strapi/client/app.js
+++ b/cockpit-api/.strapi/client/app.js
@@ -5,7 +5,6 @@
 import graphql from "@strapi/plugin-graphql/strapi-admin";
 import i18N from "@strapi/plugin-i18n/strapi-admin";
 import usersPermissions from "@strapi/plugin-users-permissions/strapi-admin";
-import importExportEntries from "strapi-plugin-import-export-entries/strapi-admin";
 import { renderAdmin } from "@strapi/strapi/admin";
 
 renderAdmin(document.getElementById("strapi"), {
@@ -13,6 +12,5 @@ renderAdmin(document.getElementById("strapi"), {
     graphql: graphql,
     i18n: i18N,
     "users-permissions": usersPermissions,
-    "import-export-entries": importExportEntries,
   },
 });

--- a/cockpit-api/package-lock.json
+++ b/cockpit-api/package-lock.json
@@ -17,7 +17,6 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^5.3.4",
-        "strapi-plugin-import-export-entries": "^1.21.1",
         "styled-components": "^5.3.3"
       },
       "engines": {
@@ -573,9 +572,9 @@
       }
     },
     "node_modules/@babel/plugin-syntax-jsx": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.22.5.tgz",
-      "integrity": "sha512-gvyP4hZrgrs/wWMaocvxZ44Hw0b3W8Pe+cMxc8V1ULQ07oh8VNbIRaoD1LRZVTvD+0nieDKjfgKg89sD7rrKrg==",
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.23.3.tgz",
+      "integrity": "sha512-EB2MELswq55OHUoRZLGg/zC7QWUKfNLpE57m/S2yr1uEneIgsTgrSzXP3NXEsMkVn76OlaVVnzN+ugObuYGwhg==",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.22.5"
       },
@@ -695,9 +694,9 @@
       }
     },
     "node_modules/@codemirror/autocomplete": {
-      "version": "6.10.2",
-      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.10.2.tgz",
-      "integrity": "sha512-3dCL7b0j2GdtZzWN5j7HDpRAJ26ip07R4NGYz7QYthIYMiX8I4E4TNrYcdTayPJGeVQtd/xe7lWU4XL7THFb/w==",
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.11.0.tgz",
+      "integrity": "sha512-LCPH3W+hl5vcO7OzEQgX6NpKuKVyiKFLGAy7FXROF6nUpsWUdQEgUb3fe/g7B0E1KZCRFfgzdKASt6Wly2UOBg==",
       "dependencies": {
         "@codemirror/language": "^6.0.0",
         "@codemirror/state": "^6.0.0",
@@ -781,9 +780,9 @@
       }
     },
     "node_modules/@codemirror/view": {
-      "version": "6.21.4",
-      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.21.4.tgz",
-      "integrity": "sha512-WKVZ7nvN0lwWPfAf05WxWqTpwjC8YN3q5goj3CsSig7//DD81LULgOx3nBegqpqP0iygBqRmW8z0KSc2QTAdAg==",
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.22.0.tgz",
+      "integrity": "sha512-6zLj4YIoIpfTGKrDMTbeZRpa8ih4EymMCKmddEDcJWrCdp/N1D46B38YEz4creTb4T177AVS9EyXkLeC/HL2jA==",
       "dependencies": {
         "@codemirror/state": "^6.1.4",
         "style-mod": "^4.1.0",
@@ -865,17 +864,12 @@
       "integrity": "sha512-gJB6HLm5rYwSLI6PQa+X1t5CFGrv1J1TWG+sOyMCeKz2ojaj6Fnl/rZEspogG+cvqbt4AE/2eIyD2QfLKTBNlQ=="
     },
     "node_modules/@emotion/is-prop-valid": {
-      "version": "0.8.8",
-      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz",
-      "integrity": "sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.1.tgz",
+      "integrity": "sha512-61Mf7Ufx4aDxx1xlDeOm8aFFigGHE4z+0sKCa+IHCeZKiyP9RLD0Mmx7m8b9/Cf37f7NAvQOOJAbQQGVr5uERw==",
       "dependencies": {
-        "@emotion/memoize": "0.7.4"
+        "@emotion/memoize": "^0.8.1"
       }
-    },
-    "node_modules/@emotion/is-prop-valid/node_modules/@emotion/memoize": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
-      "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw=="
     },
     "node_modules/@emotion/memoize": {
       "version": "0.8.1",
@@ -1298,9 +1292,9 @@
       }
     },
     "node_modules/@floating-ui/react-dom": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.0.2.tgz",
-      "integrity": "sha512-5qhlDvjaLmAst/rKb3VdlCinwTF4EYMiVxuuc/HVUjs46W0zgtbMmAZ1UTsDrRTxRmUEzl92mOtWbeeXL26lSQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.0.4.tgz",
+      "integrity": "sha512-CF8k2rgKeh/49UrnIBs4BdxPUV6vize/Db1d/YbCLyp9GiVZ0BEwf5AiDSxJRCr6yOkGqTFHtmrULxkEfYZ7dQ==",
       "dependencies": {
         "@floating-ui/dom": "^1.5.1"
       },
@@ -1587,19 +1581,6 @@
         "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
-    "node_modules/@hapi/hoek": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
-      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ=="
-    },
-    "node_modules/@hapi/topo": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
-      "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
-      "dependencies": {
-        "@hapi/hoek": "^9.0.0"
-      }
-    },
     "node_modules/@internationalized/date": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.5.0.tgz",
@@ -1609,9 +1590,9 @@
       }
     },
     "node_modules/@internationalized/number": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@internationalized/number/-/number-3.3.0.tgz",
-      "integrity": "sha512-PuxgnKE5NJMOGKUcX1QROo8jq7sW7UWLrL5B6Rfe8BdWgU/be04cVvLyCeALD46vvbAv3d1mUvyHav/Q9a237g==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@internationalized/number/-/number-3.4.0.tgz",
+      "integrity": "sha512-8TvotW3qVDHC4uv/BVoN6Qx0Dm8clHY1/vpH+dh+XRiPW/9NVpKn1P8d1A+WLphWrMwyqyWXI7uWehJPviaeIw==",
       "dependencies": {
         "@swc/helpers": "^0.5.0"
       }
@@ -1706,14 +1687,14 @@
       }
     },
     "node_modules/@lezer/common": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.1.0.tgz",
-      "integrity": "sha512-XPIN3cYDXsoJI/oDWoR2tD++juVrhgIago9xyKhZ7IhGlzdDM9QgC8D8saKNCz5pindGcznFr2HBSsEQSWnSjw=="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.1.1.tgz",
+      "integrity": "sha512-aAPB9YbvZHqAW+bIwiuuTDGB4DG0sYNRObGLxud8cW7osw1ZQxfDuTZ8KQiqfZ0QJGcR34CvpTMDXEyo/+Htgg=="
     },
     "node_modules/@lezer/highlight": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.1.6.tgz",
-      "integrity": "sha512-cmSJYa2us+r3SePpRCjN5ymCqCPv+zyXmDl0ciWtVaNiORT/MxM7ZgOMQZADD0o51qOaOg24qc/zBViOIwAjJg==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.0.tgz",
+      "integrity": "sha512-WrS5Mw51sGrpqjlh3d4/fOwpEV2Hd3YOkp9DBt4k8XZQcoTHZFB7sx030A6OcahF4J1nDQAa3jXlTVVYH50IFA==",
       "dependencies": {
         "@lezer/common": "^1.0.0"
       }
@@ -1733,31 +1714,6 @@
       "integrity": "sha512-z5mY4LStlA3yL7aHT/rqgG614cfcvklS+8oFRFBYrs4YaWLJyKKM4+nN6KopToX0o9Hj6zmH6M5kinOYuy06ug==",
       "dependencies": {
         "@lezer/common": "^1.0.0"
-      }
-    },
-    "node_modules/@monaco-editor/loader": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@monaco-editor/loader/-/loader-1.4.0.tgz",
-      "integrity": "sha512-00ioBig0x642hytVspPl7DbQyaSWRaolYie/UFNjoTdvoKPzo6xrXLhTk9ixgIKcLH5b5vDOjVNiGyY+uDCUlg==",
-      "dependencies": {
-        "state-local": "^1.0.6"
-      },
-      "peerDependencies": {
-        "monaco-editor": ">= 0.21.0 < 1"
-      }
-    },
-    "node_modules/@monaco-editor/react": {
-      "version": "4.4.5",
-      "resolved": "https://registry.npmjs.org/@monaco-editor/react/-/react-4.4.5.tgz",
-      "integrity": "sha512-IImtzU7sRc66OOaQVCG+5PFHkSWnnhrUWGBuH6zNmH2h0YgmAhcjHZQc/6MY9JWEbUtVF1WPBMJ9u1XuFbRrVA==",
-      "dependencies": {
-        "@monaco-editor/loader": "^1.3.2",
-        "prop-types": "^15.7.2"
-      },
-      "peerDependencies": {
-        "monaco-editor": ">= 0.25.0 < 1",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -2846,24 +2802,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/@sideway/address": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.4.tgz",
-      "integrity": "sha512-7vwq+rOHVWjyXxVlR76Agnvhy8I9rpzjosTESvmhNeXOXdZZB15Fl+TI9x1SiHZH5Jv2wTGduSxFDIaq0m3DUw==",
-      "dependencies": {
-        "@hapi/hoek": "^9.0.0"
-      }
-    },
-    "node_modules/@sideway/formula": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.1.tgz",
-      "integrity": "sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg=="
-    },
-    "node_modules/@sideway/pinpoint": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
-      "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ=="
-    },
     "node_modules/@simov/deep-extend": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@simov/deep-extend/-/deep-extend-1.0.0.tgz",
@@ -3040,6 +2978,128 @@
         "styled-components": "^5.2.1"
       }
     },
+    "node_modules/@strapi/admin/node_modules/@emotion/is-prop-valid": {
+      "version": "0.8.8",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz",
+      "integrity": "sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==",
+      "dependencies": {
+        "@emotion/memoize": "0.7.4"
+      }
+    },
+    "node_modules/@strapi/admin/node_modules/@emotion/memoize": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
+      "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw=="
+    },
+    "node_modules/@strapi/admin/node_modules/@emotion/unitless": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
+      "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg=="
+    },
+    "node_modules/@strapi/admin/node_modules/@strapi/design-system": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@strapi/design-system/-/design-system-1.13.0.tgz",
+      "integrity": "sha512-Z9wZyqzRKNXKNkeNAwSLYOHshXW6UmqsOvaeUiUDfE77hvsJOzR60nLDDfo9pzQ/24t9332NWUUa24mSXFt97Q==",
+      "dependencies": {
+        "@codemirror/lang-json": "^6.0.1",
+        "@floating-ui/react-dom": "^2.0.2",
+        "@internationalized/date": "^3.5.0",
+        "@internationalized/number": "^3.3.0",
+        "@radix-ui/react-dismissable-layer": "^1.0.5",
+        "@radix-ui/react-dropdown-menu": "^2.0.6",
+        "@radix-ui/react-focus-scope": "1.0.4",
+        "@strapi/ui-primitives": "^1.13.0",
+        "@uiw/react-codemirror": "^4.21.20",
+        "aria-hidden": "^1.2.3",
+        "compute-scroll-into-view": "^3.1.0",
+        "prop-types": "^15.8.1",
+        "react-remove-scroll": "^2.5.7"
+      },
+      "peerDependencies": {
+        "@strapi/icons": "^1.5.0",
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0",
+        "react-router-dom": "^5.2.0",
+        "styled-components": "^5.2.1"
+      }
+    },
+    "node_modules/@strapi/admin/node_modules/@strapi/helper-plugin": {
+      "version": "4.15.4",
+      "resolved": "https://registry.npmjs.org/@strapi/helper-plugin/-/helper-plugin-4.15.4.tgz",
+      "integrity": "sha512-JMPlV1T1W7NKIqiik3GoxUDXwfRjkfY9WIwZhWXb2F2Bubw4Akcm9aEmyGobApIdvK7XpRCt5Bp7IQkbnpQLFg==",
+      "dependencies": {
+        "axios": "1.5.0",
+        "date-fns": "2.30.0",
+        "formik": "2.4.0",
+        "immer": "9.0.19",
+        "lodash": "4.17.21",
+        "qs": "6.11.1",
+        "react-helmet": "6.1.0",
+        "react-intl": "6.4.1",
+        "react-query": "3.39.3",
+        "react-select": "5.7.0"
+      },
+      "engines": {
+        "node": ">=18.0.0 <=20.x.x",
+        "npm": ">=6.0.0"
+      },
+      "peerDependencies": {
+        "@strapi/design-system": "1.13.0",
+        "@strapi/icons": "1.13.0",
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0",
+        "react-router-dom": "^5.2.0",
+        "styled-components": "^5.2.1"
+      }
+    },
+    "node_modules/@strapi/admin/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@strapi/admin/node_modules/styled-components": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.3.3.tgz",
+      "integrity": "sha512-++4iHwBM7ZN+x6DtPPWkCI4vdtwumQ+inA/DdAsqYd4SVgUKJie5vXyzotA00ttcFdQkCng7zc6grwlfIfw+lw==",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.0.0",
+        "@babel/traverse": "^7.4.5",
+        "@emotion/is-prop-valid": "^0.8.8",
+        "@emotion/stylis": "^0.8.4",
+        "@emotion/unitless": "^0.7.4",
+        "babel-plugin-styled-components": ">= 1.12.0",
+        "css-to-react-native": "^3.0.0",
+        "hoist-non-react-statics": "^3.0.0",
+        "shallowequal": "^1.1.0",
+        "supports-color": "^5.5.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/styled-components"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0",
+        "react-dom": ">= 16.8.0",
+        "react-is": ">= 16.8.0"
+      }
+    },
+    "node_modules/@strapi/admin/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/@strapi/data-transfer": {
       "version": "4.15.4",
       "resolved": "https://registry.npmjs.org/@strapi/data-transfer/-/data-transfer-4.15.4.tgz",
@@ -3091,33 +3151,6 @@
         "npm": ">=6.0.0"
       }
     },
-    "node_modules/@strapi/design-system": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/@strapi/design-system/-/design-system-1.13.0.tgz",
-      "integrity": "sha512-Z9wZyqzRKNXKNkeNAwSLYOHshXW6UmqsOvaeUiUDfE77hvsJOzR60nLDDfo9pzQ/24t9332NWUUa24mSXFt97Q==",
-      "dependencies": {
-        "@codemirror/lang-json": "^6.0.1",
-        "@floating-ui/react-dom": "^2.0.2",
-        "@internationalized/date": "^3.5.0",
-        "@internationalized/number": "^3.3.0",
-        "@radix-ui/react-dismissable-layer": "^1.0.5",
-        "@radix-ui/react-dropdown-menu": "^2.0.6",
-        "@radix-ui/react-focus-scope": "1.0.4",
-        "@strapi/ui-primitives": "^1.13.0",
-        "@uiw/react-codemirror": "^4.21.20",
-        "aria-hidden": "^1.2.3",
-        "compute-scroll-into-view": "^3.1.0",
-        "prop-types": "^15.8.1",
-        "react-remove-scroll": "^2.5.7"
-      },
-      "peerDependencies": {
-        "@strapi/icons": "^1.5.0",
-        "react": "^17.0.0 || ^18.0.0",
-        "react-dom": "^17.0.0 || ^18.0.0",
-        "react-router-dom": "^5.2.0",
-        "styled-components": "^5.2.1"
-      }
-    },
     "node_modules/@strapi/generate-new": {
       "version": "4.15.4",
       "resolved": "https://registry.npmjs.org/@strapi/generate-new/-/generate-new-4.15.4.tgz",
@@ -3158,35 +3191,6 @@
       "engines": {
         "node": ">=18.0.0 <=20.x.x",
         "npm": ">=6.0.0"
-      }
-    },
-    "node_modules/@strapi/helper-plugin": {
-      "version": "4.15.4",
-      "resolved": "https://registry.npmjs.org/@strapi/helper-plugin/-/helper-plugin-4.15.4.tgz",
-      "integrity": "sha512-JMPlV1T1W7NKIqiik3GoxUDXwfRjkfY9WIwZhWXb2F2Bubw4Akcm9aEmyGobApIdvK7XpRCt5Bp7IQkbnpQLFg==",
-      "dependencies": {
-        "axios": "1.5.0",
-        "date-fns": "2.30.0",
-        "formik": "2.4.0",
-        "immer": "9.0.19",
-        "lodash": "4.17.21",
-        "qs": "6.11.1",
-        "react-helmet": "6.1.0",
-        "react-intl": "6.4.1",
-        "react-query": "3.39.3",
-        "react-select": "5.7.0"
-      },
-      "engines": {
-        "node": ">=18.0.0 <=20.x.x",
-        "npm": ">=6.0.0"
-      },
-      "peerDependencies": {
-        "@strapi/design-system": "1.13.0",
-        "@strapi/icons": "1.13.0",
-        "react": "^17.0.0 || ^18.0.0",
-        "react-dom": "^17.0.0 || ^18.0.0",
-        "react-router-dom": "^5.2.0",
-        "styled-components": "^5.2.1"
       }
     },
     "node_modules/@strapi/icons": {
@@ -3285,68 +3289,6 @@
         "npm": ">=6.0.0"
       }
     },
-    "node_modules/@strapi/plugin-content-type-builder": {
-      "version": "4.15.4",
-      "resolved": "https://registry.npmjs.org/@strapi/plugin-content-type-builder/-/plugin-content-type-builder-4.15.4.tgz",
-      "integrity": "sha512-OCzeh4soswNjMvF0ikUkt5Qi/oXm9G+llUMkrgT6ifFbP5A1v2A56GYas+G+ocNJqAbqA10rqq5UowHitQ1yjg==",
-      "dependencies": {
-        "@sindresorhus/slugify": "1.1.0",
-        "@strapi/design-system": "1.13.0",
-        "@strapi/generators": "4.15.4",
-        "@strapi/helper-plugin": "4.15.4",
-        "@strapi/icons": "1.13.0",
-        "@strapi/utils": "4.15.4",
-        "fs-extra": "10.0.0",
-        "immer": "9.0.19",
-        "lodash": "4.17.21",
-        "pluralize": "8.0.0",
-        "prop-types": "^15.8.1",
-        "qs": "6.11.1",
-        "react-helmet": "^6.1.0",
-        "react-intl": "6.4.1",
-        "react-redux": "8.1.1",
-        "yup": "0.32.9"
-      },
-      "engines": {
-        "node": ">=18.0.0 <=20.x.x",
-        "npm": ">=6.0.0"
-      },
-      "peerDependencies": {
-        "@strapi/strapi": "^4.0.0",
-        "react": "^17.0.0 || ^18.0.0",
-        "react-dom": "^17.0.0 || ^18.0.0",
-        "react-router-dom": "^5.2.0",
-        "styled-components": "^5.2.1"
-      }
-    },
-    "node_modules/@strapi/plugin-email": {
-      "version": "4.15.4",
-      "resolved": "https://registry.npmjs.org/@strapi/plugin-email/-/plugin-email-4.15.4.tgz",
-      "integrity": "sha512-my/A5wEHzio8TY4mkRcTKH23QF1pbwNRAoSqVN9k+32PC90w7sIa0upobYXoNs/lRwrsKHDZUyDAv2dEdWwWxw==",
-      "dependencies": {
-        "@strapi/design-system": "1.13.0",
-        "@strapi/helper-plugin": "4.15.4",
-        "@strapi/icons": "1.13.0",
-        "@strapi/provider-email-sendmail": "4.15.4",
-        "@strapi/utils": "4.15.4",
-        "lodash": "4.17.21",
-        "prop-types": "^15.8.1",
-        "react-intl": "6.4.1",
-        "react-query": "3.39.3",
-        "yup": "0.32.9"
-      },
-      "engines": {
-        "node": ">=18.0.0 <=20.x.x",
-        "npm": ">=6.0.0"
-      },
-      "peerDependencies": {
-        "koa": "2.13.4",
-        "react": "^17.0.0 || ^18.0.0",
-        "react-dom": "^17.0.0 || ^18.0.0",
-        "react-router-dom": "^5.2.0",
-        "styled-components": "^5.2.1"
-      }
-    },
     "node_modules/@strapi/plugin-graphql": {
       "version": "4.15.4",
       "resolved": "https://registry.npmjs.org/@strapi/plugin-graphql/-/plugin-graphql-4.15.4.tgz",
@@ -3376,6 +3318,62 @@
       },
       "peerDependencies": {
         "@strapi/strapi": "^4.0.0",
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0",
+        "react-router-dom": "^5.2.0",
+        "styled-components": "^5.2.1"
+      }
+    },
+    "node_modules/@strapi/plugin-graphql/node_modules/@strapi/design-system": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@strapi/design-system/-/design-system-1.13.0.tgz",
+      "integrity": "sha512-Z9wZyqzRKNXKNkeNAwSLYOHshXW6UmqsOvaeUiUDfE77hvsJOzR60nLDDfo9pzQ/24t9332NWUUa24mSXFt97Q==",
+      "dependencies": {
+        "@codemirror/lang-json": "^6.0.1",
+        "@floating-ui/react-dom": "^2.0.2",
+        "@internationalized/date": "^3.5.0",
+        "@internationalized/number": "^3.3.0",
+        "@radix-ui/react-dismissable-layer": "^1.0.5",
+        "@radix-ui/react-dropdown-menu": "^2.0.6",
+        "@radix-ui/react-focus-scope": "1.0.4",
+        "@strapi/ui-primitives": "^1.13.0",
+        "@uiw/react-codemirror": "^4.21.20",
+        "aria-hidden": "^1.2.3",
+        "compute-scroll-into-view": "^3.1.0",
+        "prop-types": "^15.8.1",
+        "react-remove-scroll": "^2.5.7"
+      },
+      "peerDependencies": {
+        "@strapi/icons": "^1.5.0",
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0",
+        "react-router-dom": "^5.2.0",
+        "styled-components": "^5.2.1"
+      }
+    },
+    "node_modules/@strapi/plugin-graphql/node_modules/@strapi/helper-plugin": {
+      "version": "4.15.4",
+      "resolved": "https://registry.npmjs.org/@strapi/helper-plugin/-/helper-plugin-4.15.4.tgz",
+      "integrity": "sha512-JMPlV1T1W7NKIqiik3GoxUDXwfRjkfY9WIwZhWXb2F2Bubw4Akcm9aEmyGobApIdvK7XpRCt5Bp7IQkbnpQLFg==",
+      "dependencies": {
+        "axios": "1.5.0",
+        "date-fns": "2.30.0",
+        "formik": "2.4.0",
+        "immer": "9.0.19",
+        "lodash": "4.17.21",
+        "qs": "6.11.1",
+        "react-helmet": "6.1.0",
+        "react-intl": "6.4.1",
+        "react-query": "3.39.3",
+        "react-select": "5.7.0"
+      },
+      "engines": {
+        "node": ">=18.0.0 <=20.x.x",
+        "npm": ">=6.0.0"
+      },
+      "peerDependencies": {
+        "@strapi/design-system": "1.13.0",
+        "@strapi/icons": "1.13.0",
         "react": "^17.0.0 || ^18.0.0",
         "react-dom": "^17.0.0 || ^18.0.0",
         "react-router-dom": "^5.2.0",
@@ -3414,44 +3412,56 @@
         "styled-components": "^5.2.1"
       }
     },
-    "node_modules/@strapi/plugin-upload": {
-      "version": "4.15.4",
-      "resolved": "https://registry.npmjs.org/@strapi/plugin-upload/-/plugin-upload-4.15.4.tgz",
-      "integrity": "sha512-tCYzLs09EoXAepn5SeP6gto3YMC/Pg256pCCB4Ogf/oSUZxJK86GYVnEkSkeB+Ho/JOLHVeknK5iO7NBfLGRhw==",
+    "node_modules/@strapi/plugin-i18n/node_modules/@strapi/design-system": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@strapi/design-system/-/design-system-1.13.0.tgz",
+      "integrity": "sha512-Z9wZyqzRKNXKNkeNAwSLYOHshXW6UmqsOvaeUiUDfE77hvsJOzR60nLDDfo9pzQ/24t9332NWUUa24mSXFt97Q==",
       "dependencies": {
-        "@strapi/design-system": "1.13.0",
-        "@strapi/helper-plugin": "4.15.4",
-        "@strapi/icons": "1.13.0",
-        "@strapi/provider-upload-local": "4.15.4",
-        "@strapi/utils": "4.15.4",
+        "@codemirror/lang-json": "^6.0.1",
+        "@floating-ui/react-dom": "^2.0.2",
+        "@internationalized/date": "^3.5.0",
+        "@internationalized/number": "^3.3.0",
+        "@radix-ui/react-dismissable-layer": "^1.0.5",
+        "@radix-ui/react-dropdown-menu": "^2.0.6",
+        "@radix-ui/react-focus-scope": "1.0.4",
+        "@strapi/ui-primitives": "^1.13.0",
+        "@uiw/react-codemirror": "^4.21.20",
+        "aria-hidden": "^1.2.3",
+        "compute-scroll-into-view": "^3.1.0",
+        "prop-types": "^15.8.1",
+        "react-remove-scroll": "^2.5.7"
+      },
+      "peerDependencies": {
+        "@strapi/icons": "^1.5.0",
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0",
+        "react-router-dom": "^5.2.0",
+        "styled-components": "^5.2.1"
+      }
+    },
+    "node_modules/@strapi/plugin-i18n/node_modules/@strapi/helper-plugin": {
+      "version": "4.15.4",
+      "resolved": "https://registry.npmjs.org/@strapi/helper-plugin/-/helper-plugin-4.15.4.tgz",
+      "integrity": "sha512-JMPlV1T1W7NKIqiik3GoxUDXwfRjkfY9WIwZhWXb2F2Bubw4Akcm9aEmyGobApIdvK7XpRCt5Bp7IQkbnpQLFg==",
+      "dependencies": {
         "axios": "1.5.0",
-        "byte-size": "7.0.1",
-        "cropperjs": "1.6.0",
         "date-fns": "2.30.0",
         "formik": "2.4.0",
-        "fs-extra": "10.0.0",
         "immer": "9.0.19",
-        "koa-range": "0.3.0",
-        "koa-static": "5.0.0",
         "lodash": "4.17.21",
-        "mime-types": "2.1.35",
-        "prop-types": "^15.8.1",
         "qs": "6.11.1",
-        "react-dnd": "15.1.2",
-        "react-helmet": "^6.1.0",
+        "react-helmet": "6.1.0",
         "react-intl": "6.4.1",
         "react-query": "3.39.3",
-        "react-redux": "8.1.1",
-        "react-select": "5.7.0",
-        "sharp": "0.32.6",
-        "yup": "0.32.9"
+        "react-select": "5.7.0"
       },
       "engines": {
         "node": ">=18.0.0 <=20.x.x",
         "npm": ">=6.0.0"
       },
       "peerDependencies": {
-        "@strapi/strapi": "^4.0.0",
+        "@strapi/design-system": "1.13.0",
+        "@strapi/icons": "1.13.0",
         "react": "^17.0.0 || ^18.0.0",
         "react-dom": "^17.0.0 || ^18.0.0",
         "react-router-dom": "^5.2.0",
@@ -3490,6 +3500,62 @@
       },
       "peerDependencies": {
         "@strapi/strapi": "^4.0.0",
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0",
+        "react-router-dom": "^5.2.0",
+        "styled-components": "^5.2.1"
+      }
+    },
+    "node_modules/@strapi/plugin-users-permissions/node_modules/@strapi/design-system": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@strapi/design-system/-/design-system-1.13.0.tgz",
+      "integrity": "sha512-Z9wZyqzRKNXKNkeNAwSLYOHshXW6UmqsOvaeUiUDfE77hvsJOzR60nLDDfo9pzQ/24t9332NWUUa24mSXFt97Q==",
+      "dependencies": {
+        "@codemirror/lang-json": "^6.0.1",
+        "@floating-ui/react-dom": "^2.0.2",
+        "@internationalized/date": "^3.5.0",
+        "@internationalized/number": "^3.3.0",
+        "@radix-ui/react-dismissable-layer": "^1.0.5",
+        "@radix-ui/react-dropdown-menu": "^2.0.6",
+        "@radix-ui/react-focus-scope": "1.0.4",
+        "@strapi/ui-primitives": "^1.13.0",
+        "@uiw/react-codemirror": "^4.21.20",
+        "aria-hidden": "^1.2.3",
+        "compute-scroll-into-view": "^3.1.0",
+        "prop-types": "^15.8.1",
+        "react-remove-scroll": "^2.5.7"
+      },
+      "peerDependencies": {
+        "@strapi/icons": "^1.5.0",
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0",
+        "react-router-dom": "^5.2.0",
+        "styled-components": "^5.2.1"
+      }
+    },
+    "node_modules/@strapi/plugin-users-permissions/node_modules/@strapi/helper-plugin": {
+      "version": "4.15.4",
+      "resolved": "https://registry.npmjs.org/@strapi/helper-plugin/-/helper-plugin-4.15.4.tgz",
+      "integrity": "sha512-JMPlV1T1W7NKIqiik3GoxUDXwfRjkfY9WIwZhWXb2F2Bubw4Akcm9aEmyGobApIdvK7XpRCt5Bp7IQkbnpQLFg==",
+      "dependencies": {
+        "axios": "1.5.0",
+        "date-fns": "2.30.0",
+        "formik": "2.4.0",
+        "immer": "9.0.19",
+        "lodash": "4.17.21",
+        "qs": "6.11.1",
+        "react-helmet": "6.1.0",
+        "react-intl": "6.4.1",
+        "react-query": "3.39.3",
+        "react-select": "5.7.0"
+      },
+      "engines": {
+        "node": ">=18.0.0 <=20.x.x",
+        "npm": ">=6.0.0"
+      },
+      "peerDependencies": {
+        "@strapi/design-system": "1.13.0",
+        "@strapi/icons": "1.13.0",
         "react": "^17.0.0 || ^18.0.0",
         "react-dom": "^17.0.0 || ^18.0.0",
         "react-router-dom": "^5.2.0",
@@ -3604,6 +3670,168 @@
         "npm": ">=6.0.0"
       }
     },
+    "node_modules/@strapi/strapi/node_modules/@strapi/design-system": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@strapi/design-system/-/design-system-1.13.0.tgz",
+      "integrity": "sha512-Z9wZyqzRKNXKNkeNAwSLYOHshXW6UmqsOvaeUiUDfE77hvsJOzR60nLDDfo9pzQ/24t9332NWUUa24mSXFt97Q==",
+      "dependencies": {
+        "@codemirror/lang-json": "^6.0.1",
+        "@floating-ui/react-dom": "^2.0.2",
+        "@internationalized/date": "^3.5.0",
+        "@internationalized/number": "^3.3.0",
+        "@radix-ui/react-dismissable-layer": "^1.0.5",
+        "@radix-ui/react-dropdown-menu": "^2.0.6",
+        "@radix-ui/react-focus-scope": "1.0.4",
+        "@strapi/ui-primitives": "^1.13.0",
+        "@uiw/react-codemirror": "^4.21.20",
+        "aria-hidden": "^1.2.3",
+        "compute-scroll-into-view": "^3.1.0",
+        "prop-types": "^15.8.1",
+        "react-remove-scroll": "^2.5.7"
+      },
+      "peerDependencies": {
+        "@strapi/icons": "^1.5.0",
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0",
+        "react-router-dom": "^5.2.0",
+        "styled-components": "^5.2.1"
+      }
+    },
+    "node_modules/@strapi/strapi/node_modules/@strapi/helper-plugin": {
+      "version": "4.15.4",
+      "resolved": "https://registry.npmjs.org/@strapi/helper-plugin/-/helper-plugin-4.15.4.tgz",
+      "integrity": "sha512-JMPlV1T1W7NKIqiik3GoxUDXwfRjkfY9WIwZhWXb2F2Bubw4Akcm9aEmyGobApIdvK7XpRCt5Bp7IQkbnpQLFg==",
+      "dependencies": {
+        "axios": "1.5.0",
+        "date-fns": "2.30.0",
+        "formik": "2.4.0",
+        "immer": "9.0.19",
+        "lodash": "4.17.21",
+        "qs": "6.11.1",
+        "react-helmet": "6.1.0",
+        "react-intl": "6.4.1",
+        "react-query": "3.39.3",
+        "react-select": "5.7.0"
+      },
+      "engines": {
+        "node": ">=18.0.0 <=20.x.x",
+        "npm": ">=6.0.0"
+      },
+      "peerDependencies": {
+        "@strapi/design-system": "1.13.0",
+        "@strapi/icons": "1.13.0",
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0",
+        "react-router-dom": "^5.2.0",
+        "styled-components": "^5.2.1"
+      }
+    },
+    "node_modules/@strapi/strapi/node_modules/@strapi/plugin-content-type-builder": {
+      "version": "4.15.4",
+      "resolved": "https://registry.npmjs.org/@strapi/plugin-content-type-builder/-/plugin-content-type-builder-4.15.4.tgz",
+      "integrity": "sha512-OCzeh4soswNjMvF0ikUkt5Qi/oXm9G+llUMkrgT6ifFbP5A1v2A56GYas+G+ocNJqAbqA10rqq5UowHitQ1yjg==",
+      "dependencies": {
+        "@sindresorhus/slugify": "1.1.0",
+        "@strapi/design-system": "1.13.0",
+        "@strapi/generators": "4.15.4",
+        "@strapi/helper-plugin": "4.15.4",
+        "@strapi/icons": "1.13.0",
+        "@strapi/utils": "4.15.4",
+        "fs-extra": "10.0.0",
+        "immer": "9.0.19",
+        "lodash": "4.17.21",
+        "pluralize": "8.0.0",
+        "prop-types": "^15.8.1",
+        "qs": "6.11.1",
+        "react-helmet": "^6.1.0",
+        "react-intl": "6.4.1",
+        "react-redux": "8.1.1",
+        "yup": "0.32.9"
+      },
+      "engines": {
+        "node": ">=18.0.0 <=20.x.x",
+        "npm": ">=6.0.0"
+      },
+      "peerDependencies": {
+        "@strapi/strapi": "^4.0.0",
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0",
+        "react-router-dom": "^5.2.0",
+        "styled-components": "^5.2.1"
+      }
+    },
+    "node_modules/@strapi/strapi/node_modules/@strapi/plugin-email": {
+      "version": "4.15.4",
+      "resolved": "https://registry.npmjs.org/@strapi/plugin-email/-/plugin-email-4.15.4.tgz",
+      "integrity": "sha512-my/A5wEHzio8TY4mkRcTKH23QF1pbwNRAoSqVN9k+32PC90w7sIa0upobYXoNs/lRwrsKHDZUyDAv2dEdWwWxw==",
+      "dependencies": {
+        "@strapi/design-system": "1.13.0",
+        "@strapi/helper-plugin": "4.15.4",
+        "@strapi/icons": "1.13.0",
+        "@strapi/provider-email-sendmail": "4.15.4",
+        "@strapi/utils": "4.15.4",
+        "lodash": "4.17.21",
+        "prop-types": "^15.8.1",
+        "react-intl": "6.4.1",
+        "react-query": "3.39.3",
+        "yup": "0.32.9"
+      },
+      "engines": {
+        "node": ">=18.0.0 <=20.x.x",
+        "npm": ">=6.0.0"
+      },
+      "peerDependencies": {
+        "koa": "2.13.4",
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0",
+        "react-router-dom": "^5.2.0",
+        "styled-components": "^5.2.1"
+      }
+    },
+    "node_modules/@strapi/strapi/node_modules/@strapi/plugin-upload": {
+      "version": "4.15.4",
+      "resolved": "https://registry.npmjs.org/@strapi/plugin-upload/-/plugin-upload-4.15.4.tgz",
+      "integrity": "sha512-tCYzLs09EoXAepn5SeP6gto3YMC/Pg256pCCB4Ogf/oSUZxJK86GYVnEkSkeB+Ho/JOLHVeknK5iO7NBfLGRhw==",
+      "dependencies": {
+        "@strapi/design-system": "1.13.0",
+        "@strapi/helper-plugin": "4.15.4",
+        "@strapi/icons": "1.13.0",
+        "@strapi/provider-upload-local": "4.15.4",
+        "@strapi/utils": "4.15.4",
+        "axios": "1.5.0",
+        "byte-size": "7.0.1",
+        "cropperjs": "1.6.0",
+        "date-fns": "2.30.0",
+        "formik": "2.4.0",
+        "fs-extra": "10.0.0",
+        "immer": "9.0.19",
+        "koa-range": "0.3.0",
+        "koa-static": "5.0.0",
+        "lodash": "4.17.21",
+        "mime-types": "2.1.35",
+        "prop-types": "^15.8.1",
+        "qs": "6.11.1",
+        "react-dnd": "15.1.2",
+        "react-helmet": "^6.1.0",
+        "react-intl": "6.4.1",
+        "react-query": "3.39.3",
+        "react-redux": "8.1.1",
+        "react-select": "5.7.0",
+        "sharp": "0.32.6",
+        "yup": "0.32.9"
+      },
+      "engines": {
+        "node": ">=18.0.0 <=20.x.x",
+        "npm": ">=6.0.0"
+      },
+      "peerDependencies": {
+        "@strapi/strapi": "^4.0.0",
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0",
+        "react-router-dom": "^5.2.0",
+        "styled-components": "^5.2.1"
+      }
+    },
     "node_modules/@strapi/types": {
       "version": "4.15.4",
       "resolved": "https://registry.npmjs.org/@strapi/types/-/types-4.15.4.tgz",
@@ -3644,9 +3872,9 @@
       }
     },
     "node_modules/@strapi/ui-primitives": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/@strapi/ui-primitives/-/ui-primitives-1.13.0.tgz",
-      "integrity": "sha512-7wWKHfWyuObfjKH2cr0TkizMndkUpCKYYxg/GvIH6fRubjomYN3TQgxixz5rWUx/azGxgtp4CtW7baYBXV+mlw==",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/@strapi/ui-primitives/-/ui-primitives-1.13.1.tgz",
+      "integrity": "sha512-HRBKU823VKuc31QCIPQptU0TQ1hwtdOzlISxHCqgPeWL3Qq33vehPc1gxxxfXh9DfZmga8Fv14g8X/1rEgDpSQ==",
       "dependencies": {
         "@radix-ui/number": "^1.0.1",
         "@radix-ui/primitive": "^1.0.1",
@@ -5078,11 +5306,6 @@
         "safe-buffer": "~5.2.0"
       }
     },
-    "node_modules/bluebird": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
-    },
     "node_modules/bn.js": {
       "version": "4.12.0",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
@@ -6226,22 +6449,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
       "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ=="
-    },
-    "node_modules/csvtojson": {
-      "version": "2.0.10",
-      "resolved": "https://registry.npmjs.org/csvtojson/-/csvtojson-2.0.10.tgz",
-      "integrity": "sha512-lUWFxGKyhraKCW8Qghz6Z0f2l/PqB1W3AO0HKJzGIQ5JRSlR651ekJDiGJbBT4sRNNv5ddnSGVEnsxP9XRCVpQ==",
-      "dependencies": {
-        "bluebird": "^3.5.1",
-        "lodash": "^4.17.3",
-        "strip-bom": "^2.0.0"
-      },
-      "bin": {
-        "csvtojson": "bin/csvtojson"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
     },
     "node_modules/date-fns": {
       "version": "2.30.0",
@@ -9612,11 +9819,6 @@
         "upper-case": "^1.1.0"
       }
     },
-    "node_modules/is-utf8": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-      "integrity": "sha512-rMYPYvCzsXywIsldgLaSoPlw5PfoB/ssr7hY4pLfcodrA5M/eArza1a9VmTiNIBNMjOGr1Ow9mTyU2o69U6U9Q=="
-    },
     "node_modules/is-windows": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
@@ -9700,18 +9902,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
-      }
-    },
-    "node_modules/joi": {
-      "version": "17.6.0",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-17.6.0.tgz",
-      "integrity": "sha512-OX5dG6DTbcr/kbMFj0KGYxuew69HPcAE3K/sZpEV2nP6e/j/C0HV+HNiBPCASxdx5T7DMoa0s8UeHWMnb6n2zw==",
-      "dependencies": {
-        "@hapi/hoek": "^9.0.0",
-        "@hapi/topo": "^5.0.0",
-        "@sideway/address": "^4.1.3",
-        "@sideway/formula": "^3.0.0",
-        "@sideway/pinpoint": "^2.0.0"
       }
     },
     "node_modules/joycon": {
@@ -10890,23 +11080,6 @@
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
-    },
-    "node_modules/monaco-editor": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.33.0.tgz",
-      "integrity": "sha512-VcRWPSLIUEgQJQIE0pVT8FcGBIgFoxz7jtqctE+IiCxWugD0DwgyQBcZBhdSrdMC84eumoqMZsGl2GTreOzwqw=="
-    },
-    "node_modules/monaco-editor-webpack-plugin": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/monaco-editor-webpack-plugin/-/monaco-editor-webpack-plugin-7.0.1.tgz",
-      "integrity": "sha512-M8qIqizltrPlIbrb73cZdTWfU9sIsUVFvAZkL3KGjAHmVWEJ0hZKa/uad14JuOckc0GwnCaoGHvMoYtJjVyCzw==",
-      "dependencies": {
-        "loader-utils": "^2.0.2"
-      },
-      "peerDependencies": {
-        "monaco-editor": ">= 0.31.0",
-        "webpack": "^4.5.0 || 5.x"
-      }
     },
     "node_modules/mrmime": {
       "version": "1.0.1",
@@ -12990,22 +13163,6 @@
         "react": "^16.3.0 || ^17.0.0 || ^18.0.0"
       }
     },
-    "node_modules/react-singleton-hook": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/react-singleton-hook/-/react-singleton-hook-3.3.0.tgz",
-      "integrity": "sha512-U0qLp7LkpqPAnSQkKNPQmMd0mhar8hAm4VL+3y/bJFoi9H817wl+gM0z7RAMfOE49E8tlCMroEavqwJa6wItlg==",
-      "peerDependencies": {
-        "react": "15 - 18"
-      },
-      "peerDependenciesMeta": {
-        "react-dom": {
-          "optional": true
-        },
-        "react-native": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/react-style-singleton": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.1.tgz",
@@ -14416,11 +14573,6 @@
       "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz",
       "integrity": "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw=="
     },
-    "node_modules/state-local": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/state-local/-/state-local-1.0.7.tgz",
-      "integrity": "sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w=="
-    },
     "node_modules/static-extend": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
@@ -14464,48 +14616,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/strapi-plugin-import-export-entries": {
-      "version": "1.21.1",
-      "resolved": "https://registry.npmjs.org/strapi-plugin-import-export-entries/-/strapi-plugin-import-export-entries-1.21.1.tgz",
-      "integrity": "sha512-vTU3mRRe/Wi3UG6ph4GNRFCuMXAYgn2HM1OmemNfRJV55cxCq8g7o4SDjdFvXtv6C0rgJgnukIQto++u8fojkA==",
-      "dependencies": {
-        "@monaco-editor/react": "4.4.5",
-        "csvtojson": "2.0.10",
-        "deepmerge": "^4.2.2",
-        "joi": "17.6.0",
-        "lodash": "4.17.21",
-        "monaco-editor": "0.33.0",
-        "monaco-editor-webpack-plugin": "7.0.1",
-        "node-fetch": "2.6.9",
-        "react-singleton-hook": "3.3.0"
-      },
-      "engines": {
-        "node": ">=14.19.1 <=18.x.x",
-        "npm": ">=6.0.0"
-      },
-      "peerDependencies": {
-        "@strapi/strapi": "^4.10.5"
-      }
-    },
-    "node_modules/strapi-plugin-import-export-entries/node_modules/node-fetch": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.9.tgz",
-      "integrity": "sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/stream-chain": {
       "version": "2.2.5",
       "resolved": "https://registry.npmjs.org/stream-chain/-/stream-chain-2.2.5.tgz",
@@ -14533,9 +14643,9 @@
       }
     },
     "node_modules/streamx": {
-      "version": "2.15.4",
-      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.15.4.tgz",
-      "integrity": "sha512-uSXKl88bibiUCQ1eMpItRljCzDENcDx18rsfDmV79r0e/ThfrAwxG4Y2FarQZ2G4/21xcOKmFFd1Hue+ZIDwHw==",
+      "version": "2.15.5",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.15.5.tgz",
+      "integrity": "sha512-9thPGMkKC2GctCzyCUjME3yR03x2xNo0GPKGkRw2UMYN+gqWa9uqpyNWhmsNCutU5zHmkUum0LsCRQTXUgUCAg==",
       "dependencies": {
         "fast-fifo": "^1.1.0",
         "queue-tick": "^1.0.1"
@@ -14586,17 +14696,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/strip-bom": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-      "integrity": "sha512-kwrX1y7czp1E69n2ajbG65mIo9dqvJ+8aBQXOGVxqwvNbsXdFM6Lq37dLAY3mknUwru8CfcCbfOLL/gMo+fi3g==",
-      "dependencies": {
-        "is-utf8": "^0.2.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/strip-final-newline": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
@@ -14634,13 +14733,13 @@
       "integrity": "sha512-Ca5ib8HrFn+f+0n4N4ScTIA9iTOQ7MaGS1ylHcoVqW9J7w2w8PzN6g9gKmTYgGEBH8e120+RCmhpje6jC5uGWA=="
     },
     "node_modules/styled-components": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.3.3.tgz",
-      "integrity": "sha512-++4iHwBM7ZN+x6DtPPWkCI4vdtwumQ+inA/DdAsqYd4SVgUKJie5vXyzotA00ttcFdQkCng7zc6grwlfIfw+lw==",
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.3.11.tgz",
+      "integrity": "sha512-uuzIIfnVkagcVHv9nE0VPlHPSCmXIUGKfJ42LNjxCCTDTL5sgnJ8Z7GZBq0EnLYGln77tPpEpExt2+qa+cZqSw==",
       "dependencies": {
         "@babel/helper-module-imports": "^7.0.0",
         "@babel/traverse": "^7.4.5",
-        "@emotion/is-prop-valid": "^0.8.8",
+        "@emotion/is-prop-valid": "^1.1.0",
         "@emotion/stylis": "^0.8.4",
         "@emotion/unitless": "^0.7.4",
         "babel-plugin-styled-components": ">= 1.12.0",

--- a/cockpit-api/package.json
+++ b/cockpit-api/package.json
@@ -14,11 +14,10 @@
     "@strapi/plugin-i18n": "4.15.4",
     "@strapi/plugin-users-permissions": "4.15.4",
     "@strapi/strapi": "4.15.4",
+    "better-sqlite3": "9.1.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^5.3.4",
-    "strapi-plugin-import-export-entries": "^1.21.1",
-    "better-sqlite3": "9.1.1",
     "styled-components": "^5.3.3"
   },
   "strapi": {


### PR DESCRIPTION
## Beschreibung

Dieser PR entfernt das Plugin `strapi-plugin-import-export-entries@1.21.1`, da es nicht mehr kompatibel mit `strapi@4.15.4` und `node@20.9.1` ist und es nicht genutzt wird.

### Referenzen
Dieser Pull Request löst den Issue ncs-northware/northware-development#40