### PR TITLE
Repo-wide Pull Request Template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,8 @@
+## Beschreibung
+
+### Referenzen
+Dieser Pull Request löst den Issue ncs-northware/northware-development#ISSUE-NUMBER
+
+### PR Einstellungen
+- Vergebe bitte noch die nötigen Labels und
+- Ordne den PR dem Northware Development Projekt mit dem Status New Pull Request oder Pull Request Done zu.


### PR DESCRIPTION
## Beschreibung

Das PR-Template, das bisher über [ncs-northware/.github](https://github.com/ncs-northware/.github) für alle Repos der Organisation galt, gilt voerst nur noch für [ncs-northware/northware-cockpit](https://github.com/ncs-northware/northware-cockpit) und [ncs-northware/northware-development](https://github.com/ncs-northware/northware-cockpit) und wird jeweils in den Repos abgelegt.