### PR TITLE
[dependabot/api](deps): Bump better-sqlite3 in /cockpit-api

### DIFF
--- a/cockpit-api/package-lock.json
+++ b/cockpit-api/package-lock.json
@@ -13,7 +13,7 @@
         "@strapi/plugin-i18n": "4.15.5",
         "@strapi/plugin-users-permissions": "4.15.5",
         "@strapi/strapi": "4.15.5",
-        "better-sqlite3": "9.1.1",
+        "better-sqlite3": "9.2.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^5.3.4",
@@ -5010,9 +5010,9 @@
       "integrity": "sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ=="
     },
     "node_modules/better-sqlite3": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-9.1.1.tgz",
-      "integrity": "sha512-FhW7bS7cXwkB2SFnPJrSGPmQerVSCzwBgmQ1cIRcYKxLsyiKjljzCbyEqqhYXo5TTBqt5BISiBj2YE2Sy2ynaA==",
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-9.2.2.tgz",
+      "integrity": "sha512-qwjWB46il0lsDkeB4rSRI96HyDQr8sxeu1MkBVLMrwusq1KRu4Bpt1TMI+8zIJkDUtZ3umjAkaEjIlokZKWCQw==",
       "hasInstallScript": true,
       "dependencies": {
         "bindings": "^1.5.0",

--- a/cockpit-api/package.json
+++ b/cockpit-api/package.json
@@ -14,7 +14,7 @@
     "@strapi/plugin-i18n": "4.15.5",
     "@strapi/plugin-users-permissions": "4.15.5",
     "@strapi/strapi": "4.15.5",
-    "better-sqlite3": "9.1.1",
+    "better-sqlite3": "9.2.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^5.3.4",


### PR DESCRIPTION
Brings #38 to testing before production

Bumps [better-sqlite3](https://github.com/WiseLibs/better-sqlite3) from 9.1.1 to 9.2.2.
- [Release notes](https://github.com/WiseLibs/better-sqlite3/releases)
- [Commits](https://github.com/WiseLibs/better-sqlite3/compare/v9.1.1...v9.2.2)

---
updated-dependencies:
- dependency-name: better-sqlite3 dependency-type: direct:production update-type: version-update:semver-minor ...

## Beschreibung

### Referenzen
Dieser Pull Request löst den Issue ncs-northware/northware-development#ISSUE-NUMBER

### PR Einstellungen
- Vergebe bitte noch die nötigen Labels und
- Ordne den PR dem Northware Development Projekt mit dem Status New Pull Request oder Pull Request Done zu.
