### PR TITLE
Revert strapi update v4.16.2

### DIFF
--- a/cockpit-api/package-lock.json
+++ b/cockpit-api/package-lock.json
@@ -9,10 +9,10 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@strapi/plugin-graphql": "^4.16.2",
-        "@strapi/plugin-i18n": "4.16.2",
-        "@strapi/plugin-users-permissions": "4.16.2",
-        "@strapi/strapi": "4.16.2",
+        "@strapi/plugin-graphql": "^4.15.5",
+        "@strapi/plugin-i18n": "4.15.5",
+        "@strapi/plugin-users-permissions": "4.15.5",
+        "@strapi/strapi": "4.15.5",
         "better-sqlite3": "9.2.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -625,9 +625,9 @@
       }
     },
     "node_modules/@babel/runtime-corejs3": {
-      "version": "7.23.6",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.23.6.tgz",
-      "integrity": "sha512-Djs/ZTAnpyj0nyg7p1J6oiE/tZ9G2stqAFlLGZynrW+F3k2w2jGK2mLOBxzYIOcZYA89+c3d3wXKpYLcpwcU6w==",
+      "version": "7.23.5",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.23.5.tgz",
+      "integrity": "sha512-7+ziVclejQTLYhXl+Oi1f6gTGD1XDCeLa4R472TNGQxb08zbEJ0OdNoh5Piz+57Ltmui6xR88BXR4gS3/Toslw==",
       "dependencies": {
         "core-js-pure": "^3.30.2",
         "regenerator-runtime": "^0.14.0"
@@ -864,17 +864,12 @@
       "integrity": "sha512-gJB6HLm5rYwSLI6PQa+X1t5CFGrv1J1TWG+sOyMCeKz2ojaj6Fnl/rZEspogG+cvqbt4AE/2eIyD2QfLKTBNlQ=="
     },
     "node_modules/@emotion/is-prop-valid": {
-      "version": "0.8.8",
-      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz",
-      "integrity": "sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.1.tgz",
+      "integrity": "sha512-61Mf7Ufx4aDxx1xlDeOm8aFFigGHE4z+0sKCa+IHCeZKiyP9RLD0Mmx7m8b9/Cf37f7NAvQOOJAbQQGVr5uERw==",
       "dependencies": {
-        "@emotion/memoize": "0.7.4"
+        "@emotion/memoize": "^0.8.1"
       }
-    },
-    "node_modules/@emotion/is-prop-valid/node_modules/@emotion/memoize": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
-      "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw=="
     },
     "node_modules/@emotion/memoize": {
       "version": "0.8.1",
@@ -1892,9 +1887,9 @@
       }
     },
     "node_modules/@polka/url": {
-      "version": "1.0.0-next.24",
-      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.24.tgz",
-      "integrity": "sha512-2LuNTFBIO0m7kKIQvvPHN6UE63VjpmL9rnEEaOOaiSPbZK+zUOYIzBAWcED+3XYzhYsd/0mD57VdxAEqqV52CQ=="
+      "version": "1.0.0-next.23",
+      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.23.tgz",
+      "integrity": "sha512-C16M+IYz0rgRhWZdCmK+h58JMv8vijAA61gmz2rspCSwKwzBebpdcsiUmwrtJRdphuY30i6BSLEOP8ppbNLyLg=="
     },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
@@ -2865,24 +2860,24 @@
       }
     },
     "node_modules/@strapi/admin": {
-      "version": "4.16.2",
-      "resolved": "https://registry.npmjs.org/@strapi/admin/-/admin-4.16.2.tgz",
-      "integrity": "sha512-kmz7QBGJcSjMdSA7jL3D9cj/xyZYPBiIqJFMSwMuc2P4Mr0QK1lKX3I6SCSMjLjEzjDi88vZEpuz0WUNegKQfQ==",
+      "version": "4.15.5",
+      "resolved": "https://registry.npmjs.org/@strapi/admin/-/admin-4.15.5.tgz",
+      "integrity": "sha512-/ArYIp3WjhuChj4N90y8yiWxJ50MA0RfENIwbTThcg0SKaDV1VV6sqWfY4gYe+3SCDb4ET0Y6V/v3EkYN4jUKw==",
       "dependencies": {
         "@casl/ability": "6.5.0",
         "@pmmmwh/react-refresh-webpack-plugin": "0.5.10",
         "@radix-ui/react-context": "1.0.1",
         "@radix-ui/react-toolbar": "1.0.4",
         "@reduxjs/toolkit": "1.9.7",
-        "@strapi/data-transfer": "4.16.2",
-        "@strapi/design-system": "1.13.1",
-        "@strapi/helper-plugin": "4.16.2",
+        "@strapi/data-transfer": "4.15.5",
+        "@strapi/design-system": "1.13.0",
+        "@strapi/helper-plugin": "4.15.5",
         "@strapi/icons": "1.13.0",
-        "@strapi/permissions": "4.16.2",
-        "@strapi/provider-audit-logs-local": "4.16.2",
-        "@strapi/types": "4.16.2",
-        "@strapi/typescript-utils": "4.16.2",
-        "@strapi/utils": "4.16.2",
+        "@strapi/permissions": "4.15.5",
+        "@strapi/provider-audit-logs-local": "4.15.5",
+        "@strapi/types": "4.15.5",
+        "@strapi/typescript-utils": "4.15.5",
+        "@strapi/utils": "4.15.5",
         "axios": "1.6.0",
         "bcryptjs": "2.4.3",
         "boxen": "5.1.2",
@@ -2975,7 +2970,7 @@
         "npm": ">=6.0.0"
       },
       "peerDependencies": {
-        "@strapi/data-transfer": "4.15.5",
+        "@strapi/data-transfer": "4.15.2",
         "@strapi/strapi": "^4.3.4",
         "react": "^17.0.0 || ^18.0.0",
         "react-dom": "^17.0.0 || ^18.0.0",
@@ -2983,44 +2978,81 @@
         "styled-components": "^5.2.1"
       }
     },
-    "node_modules/@strapi/content-releases": {
-      "version": "4.16.2",
-      "resolved": "https://registry.npmjs.org/@strapi/content-releases/-/content-releases-4.16.2.tgz",
-      "integrity": "sha512-m2FYLY9jkeoVdFdISLHM80eKaLrAj+1LWOCneyeunIozHP/u9NnCxPv/j9QmTItxm1C+hkYELZSz4b6i3Nq4iQ==",
+    "node_modules/@strapi/admin/node_modules/@emotion/is-prop-valid": {
+      "version": "0.8.8",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz",
+      "integrity": "sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==",
       "dependencies": {
-        "@reduxjs/toolkit": "1.9.7",
-        "@strapi/design-system": "1.13.1",
-        "@strapi/helper-plugin": "4.16.2",
-        "@strapi/icons": "1.13.0",
-        "@strapi/types": "4.16.2",
-        "@strapi/utils": "4.16.2",
-        "axios": "1.6.0",
-        "formik": "2.4.0",
-        "react-intl": "6.4.1",
-        "react-redux": "8.1.1",
-        "yup": "0.32.9"
+        "@emotion/memoize": "0.7.4"
+      }
+    },
+    "node_modules/@strapi/admin/node_modules/@emotion/memoize": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
+      "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw=="
+    },
+    "node_modules/@strapi/admin/node_modules/@emotion/unitless": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
+      "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg=="
+    },
+    "node_modules/@strapi/admin/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@strapi/admin/node_modules/styled-components": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.3.3.tgz",
+      "integrity": "sha512-++4iHwBM7ZN+x6DtPPWkCI4vdtwumQ+inA/DdAsqYd4SVgUKJie5vXyzotA00ttcFdQkCng7zc6grwlfIfw+lw==",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.0.0",
+        "@babel/traverse": "^7.4.5",
+        "@emotion/is-prop-valid": "^0.8.8",
+        "@emotion/stylis": "^0.8.4",
+        "@emotion/unitless": "^0.7.4",
+        "babel-plugin-styled-components": ">= 1.12.0",
+        "css-to-react-native": "^3.0.0",
+        "hoist-non-react-statics": "^3.0.0",
+        "shallowequal": "^1.1.0",
+        "supports-color": "^5.5.0"
       },
       "engines": {
-        "node": ">=16.0.0 <=20.x.x",
-        "npm": ">=6.0.0"
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/styled-components"
       },
       "peerDependencies": {
-        "@strapi/strapi": "^4.15.1",
-        "react": "^17.0.0 || ^18.0.0",
-        "react-dom": "^17.0.0 || ^18.0.0",
-        "react-router-dom": "5.3.4",
-        "styled-components": "5.3.3"
+        "react": ">= 16.8.0",
+        "react-dom": ">= 16.8.0",
+        "react-is": ">= 16.8.0"
+      }
+    },
+    "node_modules/@strapi/admin/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/@strapi/data-transfer": {
-      "version": "4.16.2",
-      "resolved": "https://registry.npmjs.org/@strapi/data-transfer/-/data-transfer-4.16.2.tgz",
-      "integrity": "sha512-CDJQ6Kb1H/y25zWAsdXQw9FU/F6iRYdef1dVUh0yMLZNS8HrCWAPu/jjLwrrLF6KKD8O30jMIsH1Nsdr/J5tnw==",
+      "version": "4.15.5",
+      "resolved": "https://registry.npmjs.org/@strapi/data-transfer/-/data-transfer-4.15.5.tgz",
+      "integrity": "sha512-r/6r2fA4bSLgL9b+w2GS1Ci7ul5CMzJ/V7jojwqZON4E17wlKZzwccUU/OlCjZbOBiI+6nxA55rUDth/u3NlnA==",
       "dependencies": {
-        "@strapi/logger": "4.16.2",
-        "@strapi/strapi": "4.16.2",
-        "@strapi/types": "4.16.2",
-        "@strapi/utils": "4.16.2",
+        "@strapi/logger": "4.15.5",
+        "@strapi/strapi": "4.15.5",
+        "@strapi/types": "4.15.5",
+        "@strapi/utils": "4.15.5",
         "chalk": "4.1.2",
         "cli-table3": "0.6.2",
         "commander": "8.3.0",
@@ -3045,11 +3077,11 @@
       }
     },
     "node_modules/@strapi/database": {
-      "version": "4.16.2",
-      "resolved": "https://registry.npmjs.org/@strapi/database/-/database-4.16.2.tgz",
-      "integrity": "sha512-Vq54I7vlAix/XR17mBYmxGxS8R1eXDYHhbjqlyPRMJpbG3PPvOYyEVesy6caQHjivjL/LQNmmDXoFSd7qUzOgQ==",
+      "version": "4.15.5",
+      "resolved": "https://registry.npmjs.org/@strapi/database/-/database-4.15.5.tgz",
+      "integrity": "sha512-ddeMkDt24YAuTmcugevU0vQprRHq7+Cbe89uJJKyY9juz0LijZ/lQcoPr9RjxVkYZDROOl7C6jRrU6u3WoNjTw==",
       "dependencies": {
-        "@strapi/utils": "4.16.2",
+        "@strapi/utils": "4.15.5",
         "date-fns": "2.30.0",
         "debug": "4.3.4",
         "fs-extra": "10.0.0",
@@ -3064,9 +3096,9 @@
       }
     },
     "node_modules/@strapi/design-system": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/@strapi/design-system/-/design-system-1.13.1.tgz",
-      "integrity": "sha512-mtfONSTZmOKd0Mvb1NGEYx5qaA4uDPqx5q3/67kDSK2mkfjEe3j69SoQ6ONt/glvsidclWtez6R1aJmF5cojRg==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@strapi/design-system/-/design-system-1.13.0.tgz",
+      "integrity": "sha512-Z9wZyqzRKNXKNkeNAwSLYOHshXW6UmqsOvaeUiUDfE77hvsJOzR60nLDDfo9pzQ/24t9332NWUUa24mSXFt97Q==",
       "dependencies": {
         "@codemirror/lang-json": "^6.0.1",
         "@floating-ui/react-dom": "^2.0.2",
@@ -3075,7 +3107,7 @@
         "@radix-ui/react-dismissable-layer": "^1.0.5",
         "@radix-ui/react-dropdown-menu": "^2.0.6",
         "@radix-ui/react-focus-scope": "1.0.4",
-        "@strapi/ui-primitives": "^1.13.1",
+        "@strapi/ui-primitives": "^1.13.0",
         "@uiw/react-codemirror": "^4.21.20",
         "aria-hidden": "^1.2.3",
         "compute-scroll-into-view": "^3.1.0",
@@ -3091,9 +3123,9 @@
       }
     },
     "node_modules/@strapi/generate-new": {
-      "version": "4.16.2",
-      "resolved": "https://registry.npmjs.org/@strapi/generate-new/-/generate-new-4.16.2.tgz",
-      "integrity": "sha512-bLTsS73wqjgYvQeCVcxhodG+fssjTnYcCvVHyBBzp28Gv8AoBaiUaVgVPedHGA4XpfNl1y0zQZXN2B2rrrhNjQ==",
+      "version": "4.15.5",
+      "resolved": "https://registry.npmjs.org/@strapi/generate-new/-/generate-new-4.15.5.tgz",
+      "integrity": "sha512-5XvexpopvWHjBpsi9drIOHJnxmgK7kGjBz6JimlKi4v4YXR7D8QxW6K/8xSQHrH0SxIeFN6gZq8UrSVqsUxEdA==",
       "dependencies": {
         "@sentry/node": "6.19.7",
         "chalk": "^4.1.2",
@@ -3113,13 +3145,13 @@
       }
     },
     "node_modules/@strapi/generators": {
-      "version": "4.16.2",
-      "resolved": "https://registry.npmjs.org/@strapi/generators/-/generators-4.16.2.tgz",
-      "integrity": "sha512-X4ibD/+AokFvhDtaTApQtyli3NEUkbqxhqexCQPhgWa5H+8zEpQHro8tTMHcW8l4to1EYBt2gLnVb6eh/M1Tzg==",
+      "version": "4.15.5",
+      "resolved": "https://registry.npmjs.org/@strapi/generators/-/generators-4.15.5.tgz",
+      "integrity": "sha512-RMiLiSO1ihyhaWJAQOrmm3vF0EEdmu/qAAT/gsvhsFzcXrfchaceuUr/fuDRxqt5hT8SezVizM9HiYUn5lPP3w==",
       "dependencies": {
         "@sindresorhus/slugify": "1.1.0",
-        "@strapi/typescript-utils": "4.16.2",
-        "@strapi/utils": "4.16.2",
+        "@strapi/typescript-utils": "4.15.5",
+        "@strapi/utils": "4.15.5",
         "chalk": "4.1.2",
         "copyfiles": "2.4.1",
         "fs-extra": "10.0.0",
@@ -3133,9 +3165,9 @@
       }
     },
     "node_modules/@strapi/helper-plugin": {
-      "version": "4.16.2",
-      "resolved": "https://registry.npmjs.org/@strapi/helper-plugin/-/helper-plugin-4.16.2.tgz",
-      "integrity": "sha512-O9ZWm/qHa2gZByuG4+YePvy9wfHykh4vUw7wufIWn4aTdv3AQdCIBmN33iiDXKd9Fxud+o7XIubXe2ZRTZbySQ==",
+      "version": "4.15.5",
+      "resolved": "https://registry.npmjs.org/@strapi/helper-plugin/-/helper-plugin-4.15.5.tgz",
+      "integrity": "sha512-D7CNIpsiVvwXOuyUlvn7aOZu60Hebe+h4QAge1VEvsQSVlInhyzEbRbmeE247cEhdAyrlC9ga8KzQ2M1BLypvw==",
       "dependencies": {
         "axios": "1.6.0",
         "date-fns": "2.30.0",
@@ -3153,7 +3185,7 @@
         "npm": ">=6.0.0"
       },
       "peerDependencies": {
-        "@strapi/design-system": "1.13.1",
+        "@strapi/design-system": "1.13.0",
         "@strapi/icons": "1.13.0",
         "react": "^17.0.0 || ^18.0.0",
         "react-dom": "^17.0.0 || ^18.0.0",
@@ -3171,9 +3203,9 @@
       }
     },
     "node_modules/@strapi/logger": {
-      "version": "4.16.2",
-      "resolved": "https://registry.npmjs.org/@strapi/logger/-/logger-4.16.2.tgz",
-      "integrity": "sha512-9BBU8AgQVjlM/uyCFW+tUlyVCcfQ7rlRHtGQr+ZFtHY7Thzd/vRHxvC3i34Cah7qAn8QU5aemNQJvGxH04mz+w==",
+      "version": "4.15.5",
+      "resolved": "https://registry.npmjs.org/@strapi/logger/-/logger-4.15.5.tgz",
+      "integrity": "sha512-m3Mml9B8+Yvkirv48ZekgroZS8B9CkSXOANCJOKBLzbvzhth66Y35SExTsH+AHQANke0iuI8+3b6Twzef+EDTg==",
       "dependencies": {
         "lodash": "4.17.21",
         "winston": "3.10.0"
@@ -3184,9 +3216,9 @@
       }
     },
     "node_modules/@strapi/pack-up": {
-      "version": "4.16.2",
-      "resolved": "https://registry.npmjs.org/@strapi/pack-up/-/pack-up-4.16.2.tgz",
-      "integrity": "sha512-jZNwDOQTK+wXMNCyJIzumW8w7BivCG4B1LK+jyYXTomwKnwkvLLGvJZtUdgY52a5ogJyLHKaecKhbskIuT/Fsg==",
+      "version": "4.15.5",
+      "resolved": "https://registry.npmjs.org/@strapi/pack-up/-/pack-up-4.15.5.tgz",
+      "integrity": "sha512-qxHSqUB4BpCxvh3wdYfaqRrT3vXti4jH78i0S7lMT2nmJoPHsdgwtsThoqm9lYp7TN9Xqcu9oda9GOoAnqL0JA==",
       "dependencies": {
         "@vitejs/plugin-react": "4.1.0",
         "boxen": "5.1.2",
@@ -3227,12 +3259,12 @@
       }
     },
     "node_modules/@strapi/permissions": {
-      "version": "4.16.2",
-      "resolved": "https://registry.npmjs.org/@strapi/permissions/-/permissions-4.16.2.tgz",
-      "integrity": "sha512-/vew0jV8WGXOL4DXUJrCiaCpwxVtDjMkwnAzTnkJmZQVGUu38VP+Uj2frcZpOewumCE8/k1kAGnQRMRhYmc/eA==",
+      "version": "4.15.5",
+      "resolved": "https://registry.npmjs.org/@strapi/permissions/-/permissions-4.15.5.tgz",
+      "integrity": "sha512-ClfZiNC2Uu/IrajO+CuE+XppiT1tbzX16Wcfrh7Sf/gL1GuXAEahElxBV57tnkrEm+tZCd+pFpScruwkjsbT6w==",
       "dependencies": {
         "@casl/ability": "6.5.0",
-        "@strapi/utils": "4.16.2",
+        "@strapi/utils": "4.15.5",
         "lodash": "4.17.21",
         "qs": "6.11.1",
         "sift": "16.0.1"
@@ -3243,12 +3275,12 @@
       }
     },
     "node_modules/@strapi/plugin-content-manager": {
-      "version": "4.16.2",
-      "resolved": "https://registry.npmjs.org/@strapi/plugin-content-manager/-/plugin-content-manager-4.16.2.tgz",
-      "integrity": "sha512-dpd7VwbLar0jOB1rCNJV5fyMsl/BPOEk120bhFQ45wPYcKpf/6daBklNklVgnho/8fN90cLTMzjjHET5LmabFQ==",
+      "version": "4.15.5",
+      "resolved": "https://registry.npmjs.org/@strapi/plugin-content-manager/-/plugin-content-manager-4.15.5.tgz",
+      "integrity": "sha512-AEGxYCTK/ODDPf2GXsWj75oktXlpI5wNPhjtbm5pfNrvdBJTRqntkz3QIt3UYq+NkAUzZa1kV9qwRuT/s9lqzA==",
       "dependencies": {
         "@sindresorhus/slugify": "1.1.0",
-        "@strapi/utils": "4.16.2",
+        "@strapi/utils": "4.15.5",
         "lodash": "4.17.21",
         "qs": "6.11.1"
       },
@@ -3258,16 +3290,16 @@
       }
     },
     "node_modules/@strapi/plugin-content-type-builder": {
-      "version": "4.16.2",
-      "resolved": "https://registry.npmjs.org/@strapi/plugin-content-type-builder/-/plugin-content-type-builder-4.16.2.tgz",
-      "integrity": "sha512-Xc/iFuJCerDEvpybya7xiuX0zOe/jKkFwzAf1LahKzAEk+GIiAYt1sd+AiN8iUiDIyh4CH7L+iPM3Dw5khV+Pw==",
+      "version": "4.15.5",
+      "resolved": "https://registry.npmjs.org/@strapi/plugin-content-type-builder/-/plugin-content-type-builder-4.15.5.tgz",
+      "integrity": "sha512-n9MFiKf2D+EW0i8A7Moct2dQoe1rGuTxlfDajICGdFY4IDQPIXvVTZyCdA1ANDrcDAZBkmD4+ned+4BogaVEWw==",
       "dependencies": {
         "@sindresorhus/slugify": "1.1.0",
-        "@strapi/design-system": "1.13.1",
-        "@strapi/generators": "4.16.2",
-        "@strapi/helper-plugin": "4.16.2",
+        "@strapi/design-system": "1.13.0",
+        "@strapi/generators": "4.15.5",
+        "@strapi/helper-plugin": "4.15.5",
         "@strapi/icons": "1.13.0",
-        "@strapi/utils": "4.16.2",
+        "@strapi/utils": "4.15.5",
         "fs-extra": "10.0.0",
         "immer": "9.0.19",
         "lodash": "4.17.21",
@@ -3292,15 +3324,15 @@
       }
     },
     "node_modules/@strapi/plugin-email": {
-      "version": "4.16.2",
-      "resolved": "https://registry.npmjs.org/@strapi/plugin-email/-/plugin-email-4.16.2.tgz",
-      "integrity": "sha512-WSi0k36JasovwlKbTC1uHlSe60TbX5FmVvbHDIQE7sWERoGJLFLYOetZ8HN0Qy/f1x07ltcNy4kGj9KL/O6eLw==",
+      "version": "4.15.5",
+      "resolved": "https://registry.npmjs.org/@strapi/plugin-email/-/plugin-email-4.15.5.tgz",
+      "integrity": "sha512-KCZ/zaw4nZWSl46mP1kQnID0oABYHT3CLnNbu6IlmppyrBIOIUGGrO9KqVuOANKGF23kh9XISXSMPFfkojYOng==",
       "dependencies": {
-        "@strapi/design-system": "1.13.1",
-        "@strapi/helper-plugin": "4.16.2",
+        "@strapi/design-system": "1.13.0",
+        "@strapi/helper-plugin": "4.15.5",
         "@strapi/icons": "1.13.0",
-        "@strapi/provider-email-sendmail": "4.16.2",
-        "@strapi/utils": "4.16.2",
+        "@strapi/provider-email-sendmail": "4.15.5",
+        "@strapi/utils": "4.15.5",
         "lodash": "4.17.21",
         "prop-types": "^15.8.1",
         "react-intl": "6.4.1",
@@ -3320,23 +3352,23 @@
       }
     },
     "node_modules/@strapi/plugin-graphql": {
-      "version": "4.16.2",
-      "resolved": "https://registry.npmjs.org/@strapi/plugin-graphql/-/plugin-graphql-4.16.2.tgz",
-      "integrity": "sha512-1pOqDEaSUCSe0KRempcGMY2H/KEElfVpM3kexkrVORuoNPubD/LxiqYRPaj35j2TiYF/YClPGiDy+f0WxSefzg==",
+      "version": "4.15.5",
+      "resolved": "https://registry.npmjs.org/@strapi/plugin-graphql/-/plugin-graphql-4.15.5.tgz",
+      "integrity": "sha512-X8xVgvmtpw8i73pHAetRTyrHxTH2CaOo5BgCROerxV2WpNBi8c2ImhtBq1Kwwi8BHEMJySJBE+GfmPdMMyJ5Ng==",
       "dependencies": {
         "@graphql-tools/schema": "8.5.1",
         "@graphql-tools/utils": "^8.13.1",
-        "@strapi/design-system": "1.13.1",
-        "@strapi/helper-plugin": "4.16.2",
+        "@strapi/design-system": "1.13.0",
+        "@strapi/helper-plugin": "4.15.5",
         "@strapi/icons": "1.13.0",
-        "@strapi/utils": "4.16.2",
+        "@strapi/utils": "4.15.5",
         "apollo-server-core": "3.12.1",
         "apollo-server-koa": "3.10.0",
         "graphql": "^15.5.1",
         "graphql-depth-limit": "^1.1.0",
         "graphql-playground-middleware-koa": "^1.6.21",
         "graphql-scalars": "1.22.2",
-        "graphql-upload": "15.0.2",
+        "graphql-upload": "^13.0.0",
         "koa-compose": "^4.1.0",
         "lodash": "4.17.21",
         "nexus": "1.3.0",
@@ -3354,24 +3386,16 @@
         "styled-components": "^5.2.1"
       }
     },
-    "node_modules/@strapi/plugin-graphql/node_modules/graphql": {
-      "version": "15.8.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.8.0.tgz",
-      "integrity": "sha512-5gghUc24tP9HRznNpV2+FIoq3xKkj5dTQqf4v0CpdPbFVwFkWoxOM+o+2OC9ZSvjEMTjfmG9QT+gcvggTwW1zw==",
-      "engines": {
-        "node": ">= 10.x"
-      }
-    },
     "node_modules/@strapi/plugin-i18n": {
-      "version": "4.16.2",
-      "resolved": "https://registry.npmjs.org/@strapi/plugin-i18n/-/plugin-i18n-4.16.2.tgz",
-      "integrity": "sha512-wHhgN4qWQ39L6Xn+02JZ2URojYlsZmDofAiRjYtTEcTrN5iTH2Gt9yC4OY4VHTOwwz3QMpZzYlY2lv9zvFvFJg==",
+      "version": "4.15.5",
+      "resolved": "https://registry.npmjs.org/@strapi/plugin-i18n/-/plugin-i18n-4.15.5.tgz",
+      "integrity": "sha512-yXHONAqsYMbKtq80DmFdFQlyARS/LNFcx130SHT6CE3h7IRnzEtRZMjOuRLypcF+vW90QyUDykXkZ5Nd4i2dKA==",
       "dependencies": {
         "@reduxjs/toolkit": "1.9.7",
-        "@strapi/design-system": "1.13.1",
-        "@strapi/helper-plugin": "4.16.2",
+        "@strapi/design-system": "1.13.0",
+        "@strapi/helper-plugin": "4.15.5",
         "@strapi/icons": "1.13.0",
-        "@strapi/utils": "4.16.2",
+        "@strapi/utils": "4.15.5",
         "formik": "2.4.0",
         "immer": "9.0.19",
         "lodash": "4.17.21",
@@ -3395,15 +3419,15 @@
       }
     },
     "node_modules/@strapi/plugin-upload": {
-      "version": "4.16.2",
-      "resolved": "https://registry.npmjs.org/@strapi/plugin-upload/-/plugin-upload-4.16.2.tgz",
-      "integrity": "sha512-Yj0R2iY0ZqXXcjoLKNVO8SAdw26TKnHF1QuzLojTu7vZKK9hd1VOKISRDWJ3zV/gq8JuttE7ientjyd36ayftA==",
+      "version": "4.15.5",
+      "resolved": "https://registry.npmjs.org/@strapi/plugin-upload/-/plugin-upload-4.15.5.tgz",
+      "integrity": "sha512-4rg+x3HLvdw+VueeGebxLTw7K253ST0SRpWUyUcD3qXJHwd/nYCRGaPPOyuZs5ocQ7Emh6SME9d4GvmijZZsWg==",
       "dependencies": {
-        "@strapi/design-system": "1.13.1",
-        "@strapi/helper-plugin": "4.16.2",
+        "@strapi/design-system": "1.13.0",
+        "@strapi/helper-plugin": "4.15.5",
         "@strapi/icons": "1.13.0",
-        "@strapi/provider-upload-local": "4.16.2",
-        "@strapi/utils": "4.16.2",
+        "@strapi/provider-upload-local": "4.15.5",
+        "@strapi/utils": "4.15.5",
         "axios": "1.6.0",
         "byte-size": "7.0.1",
         "cropperjs": "1.6.0",
@@ -3439,14 +3463,14 @@
       }
     },
     "node_modules/@strapi/plugin-users-permissions": {
-      "version": "4.16.2",
-      "resolved": "https://registry.npmjs.org/@strapi/plugin-users-permissions/-/plugin-users-permissions-4.16.2.tgz",
-      "integrity": "sha512-27QZSKW1WpbKYt5I/+AkiIh9o6DDQE2nHilfln6bSaW5s3htM+tFR7vdTTjbHOhpMTD6kpqLFFhKVFoDcUP1Og==",
+      "version": "4.15.5",
+      "resolved": "https://registry.npmjs.org/@strapi/plugin-users-permissions/-/plugin-users-permissions-4.15.5.tgz",
+      "integrity": "sha512-OosP6xAtRlA+NS3tOy7M0zSsWj2Jk2NjOhoSSmU9tJj08GEIc3EJHkhqwNWK6qHgGt+d4qhPQ4ltTDZ06ZXEig==",
       "dependencies": {
-        "@strapi/design-system": "1.13.1",
-        "@strapi/helper-plugin": "4.16.2",
+        "@strapi/design-system": "1.13.0",
+        "@strapi/helper-plugin": "4.15.5",
         "@strapi/icons": "1.13.0",
-        "@strapi/utils": "4.16.2",
+        "@strapi/utils": "4.15.5",
         "bcryptjs": "2.4.3",
         "formik": "2.4.0",
         "grant-koa": "5.4.8",
@@ -3477,20 +3501,20 @@
       }
     },
     "node_modules/@strapi/provider-audit-logs-local": {
-      "version": "4.16.2",
-      "resolved": "https://registry.npmjs.org/@strapi/provider-audit-logs-local/-/provider-audit-logs-local-4.16.2.tgz",
-      "integrity": "sha512-BAPX3v/EMlJVbuu0Ub7FkB0Pusl4pgVH0xujmxUeUeUnR9d4+Lkwjf4xJbr/6FSo9E+kVgHJrwVyhCg/pflIiQ==",
+      "version": "4.15.5",
+      "resolved": "https://registry.npmjs.org/@strapi/provider-audit-logs-local/-/provider-audit-logs-local-4.15.5.tgz",
+      "integrity": "sha512-yScciKDdB4WrO5zHZVIsvH66T4R0cNT8ZWlvplA8cIxQyEihEnUJg0o/+fDz7er1+8iaZrZ1mX0BlG9bR242lw==",
       "engines": {
         "node": ">=18.0.0 <=20.x.x",
         "npm": ">=6.0.0"
       }
     },
     "node_modules/@strapi/provider-email-sendmail": {
-      "version": "4.16.2",
-      "resolved": "https://registry.npmjs.org/@strapi/provider-email-sendmail/-/provider-email-sendmail-4.16.2.tgz",
-      "integrity": "sha512-cRol7bABMawuwsf9CEqxS9fZVZR1VHUE64D0kXslVz/IviK/LixoO57F66BZlZ4mi8V7SS+L8jwPN6qRlOsxOA==",
+      "version": "4.15.5",
+      "resolved": "https://registry.npmjs.org/@strapi/provider-email-sendmail/-/provider-email-sendmail-4.15.5.tgz",
+      "integrity": "sha512-5+vxzyXCqBP3yyAJ83kfLG9wjPwWKQXhS7kdPKWsyArrojPCHISTzPsOsBQSQXiQuK2/ZvU6AX++U8voCGVtJQ==",
       "dependencies": {
-        "@strapi/utils": "4.16.2",
+        "@strapi/utils": "4.15.5",
         "sendmail": "^1.6.1"
       },
       "engines": {
@@ -3499,11 +3523,11 @@
       }
     },
     "node_modules/@strapi/provider-upload-local": {
-      "version": "4.16.2",
-      "resolved": "https://registry.npmjs.org/@strapi/provider-upload-local/-/provider-upload-local-4.16.2.tgz",
-      "integrity": "sha512-fYUbAQxH3bHwKyA+36+0YBklL6mW/UG8lKrCKmA2cpHCTTIOU2VNnNSrfhIipaQaWsTf7/ZNYfgstRjuHjTayQ==",
+      "version": "4.15.5",
+      "resolved": "https://registry.npmjs.org/@strapi/provider-upload-local/-/provider-upload-local-4.15.5.tgz",
+      "integrity": "sha512-lGk5m5U/XnpI0YnjbWW2VezneU4tqHvXaKJ3eZJI6Axwkpu389O5574sKl2HcIPha1xUxK7tBpgJtkKBgmmpfA==",
       "dependencies": {
-        "@strapi/utils": "4.16.2",
+        "@strapi/utils": "4.15.5",
         "fs-extra": "10.0.0"
       },
       "engines": {
@@ -3512,29 +3536,28 @@
       }
     },
     "node_modules/@strapi/strapi": {
-      "version": "4.16.2",
-      "resolved": "https://registry.npmjs.org/@strapi/strapi/-/strapi-4.16.2.tgz",
-      "integrity": "sha512-ARYewyc6eL3LObR60XLFVTNEJJLt97CKvYlMBaE2PUEMYwcOYZEmhDng5fHNcEIIg+3vXQV7KKj4lTw+uFBQ1g==",
+      "version": "4.15.5",
+      "resolved": "https://registry.npmjs.org/@strapi/strapi/-/strapi-4.15.5.tgz",
+      "integrity": "sha512-XdGfnXXoeq18mjO2OXJi/tySwiKzfX1C5u/y30X3q21lVD5U+cAWS+WhZpUROIUOX0+nT6sWP6jjhRbRkac1oA==",
       "hasInstallScript": true,
       "dependencies": {
         "@koa/cors": "3.4.3",
         "@koa/router": "10.1.1",
-        "@strapi/admin": "4.16.2",
-        "@strapi/content-releases": "4.16.2",
-        "@strapi/data-transfer": "4.16.2",
-        "@strapi/database": "4.16.2",
-        "@strapi/generate-new": "4.16.2",
-        "@strapi/generators": "4.16.2",
-        "@strapi/logger": "4.16.2",
-        "@strapi/pack-up": "4.16.2",
-        "@strapi/permissions": "4.16.2",
-        "@strapi/plugin-content-manager": "4.16.2",
-        "@strapi/plugin-content-type-builder": "4.16.2",
-        "@strapi/plugin-email": "4.16.2",
-        "@strapi/plugin-upload": "4.16.2",
-        "@strapi/types": "4.16.2",
-        "@strapi/typescript-utils": "4.16.2",
-        "@strapi/utils": "4.16.2",
+        "@strapi/admin": "4.15.5",
+        "@strapi/data-transfer": "4.15.5",
+        "@strapi/database": "4.15.5",
+        "@strapi/generate-new": "4.15.5",
+        "@strapi/generators": "4.15.5",
+        "@strapi/logger": "4.15.5",
+        "@strapi/pack-up": "4.15.5",
+        "@strapi/permissions": "4.15.5",
+        "@strapi/plugin-content-manager": "4.15.5",
+        "@strapi/plugin-content-type-builder": "4.15.5",
+        "@strapi/plugin-email": "4.15.5",
+        "@strapi/plugin-upload": "4.15.5",
+        "@strapi/types": "4.15.5",
+        "@strapi/typescript-utils": "4.15.5",
+        "@strapi/utils": "4.15.5",
         "bcryptjs": "2.4.3",
         "boxen": "5.1.2",
         "chalk": "4.1.2",
@@ -3586,16 +3609,16 @@
       }
     },
     "node_modules/@strapi/types": {
-      "version": "4.16.2",
-      "resolved": "https://registry.npmjs.org/@strapi/types/-/types-4.16.2.tgz",
-      "integrity": "sha512-pEi4zQybOL2PRds+4sFmoEr0DQlQxP4brlmYfI8VDQiC5RR/SfNkEExcPeZ8cvIUpYKUGrzpUExZ/QLxcbRUEg==",
+      "version": "4.15.5",
+      "resolved": "https://registry.npmjs.org/@strapi/types/-/types-4.15.5.tgz",
+      "integrity": "sha512-mDG/zb8/pZO2+asjZ7YGAL8xopAhGq6TwMStxUSPPodHwLwQy/ewnIWWrigS6/cyWWv1+Py0F9mUvml5IpqyMw==",
       "dependencies": {
         "@koa/cors": "3.4.3",
         "@koa/router": "10.1.1",
-        "@strapi/database": "4.16.2",
-        "@strapi/logger": "4.16.2",
-        "@strapi/permissions": "4.16.2",
-        "@strapi/utils": "4.16.2",
+        "@strapi/database": "4.15.5",
+        "@strapi/logger": "4.15.5",
+        "@strapi/permissions": "4.15.5",
+        "@strapi/utils": "4.15.5",
         "commander": "8.3.0",
         "https-proxy-agent": "5.0.1",
         "koa": "2.13.4",
@@ -3608,9 +3631,9 @@
       }
     },
     "node_modules/@strapi/typescript-utils": {
-      "version": "4.16.2",
-      "resolved": "https://registry.npmjs.org/@strapi/typescript-utils/-/typescript-utils-4.16.2.tgz",
-      "integrity": "sha512-p8E4xvp8T5ZMQ9NNIsdgM5r31TrFbzHaDWbODOoPfvazUWtL5WEts/rmwS58HX6IYa+unuFgsYdECiosyoq3XQ==",
+      "version": "4.15.5",
+      "resolved": "https://registry.npmjs.org/@strapi/typescript-utils/-/typescript-utils-4.15.5.tgz",
+      "integrity": "sha512-zpH2npmIVgy4a8WyDeSY/zmaWXa9SWA2N7Qwx6rHGuI+sjCpExLG5CUxfpi8Tz6iMswRAkOHMtLEmiBmc9yAgg==",
       "dependencies": {
         "chalk": "4.1.2",
         "cli-table3": "0.6.2",
@@ -3657,9 +3680,9 @@
       }
     },
     "node_modules/@strapi/utils": {
-      "version": "4.16.2",
-      "resolved": "https://registry.npmjs.org/@strapi/utils/-/utils-4.16.2.tgz",
-      "integrity": "sha512-CuAXBXXke4j0OTVuQswZ8c/Mpeb9W1DhcBhYQpc8Cwn9NeII5VGE57TrIkXL3FCU8q4fcL3IrSLaftmL6/e3uQ==",
+      "version": "4.15.5",
+      "resolved": "https://registry.npmjs.org/@strapi/utils/-/utils-4.15.5.tgz",
+      "integrity": "sha512-1ARIaMh7i/lWTkPVnDX/EuWCJrIq9IrlNwToDG4tnej5ZzqhGQVD4G4n+I4nKLDjXi6qhR+7AGpcgtchBoWtRw==",
       "dependencies": {
         "@sindresorhus/slugify": "1.1.0",
         "date-fns": "2.30.0",
@@ -3723,9 +3746,9 @@
       }
     },
     "node_modules/@types/babel__generator": {
-      "version": "7.6.8",
-      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.8.tgz",
-      "integrity": "sha512-ASsj+tpEDsEiFr1arWrlN6V3mdfjRMZt6LtK/Vp/kreFLnr5QH5+DhvD5nINYZXzwJvXeGq+05iUXcAzVrqWtw==",
+      "version": "7.6.7",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.7.tgz",
+      "integrity": "sha512-6Sfsq+EaaLrw4RmdFWE9Onp63TOUue71AWb4Gpa6JxzgTYtimbM086WnYTy2U67AofR++QKCo08ZP6pwx8YFHQ==",
       "dependencies": {
         "@babel/types": "^7.0.0"
       }
@@ -3753,14 +3776,6 @@
       "integrity": "sha512-oyl4jvAfTGX9Bt6Or4H9ni1Z447/tQuxnZsytsCaExKlmJiU8sFgnIBRzJUpKwB5eWn9HuBYlUlVA74q/yN0eQ==",
       "dependencies": {
         "@types/connect": "*",
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/busboy": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/@types/busboy/-/busboy-1.5.3.tgz",
-      "integrity": "sha512-YMBLFN/xBD8bnqywIlGyYqsNFXu6bsiY7h3Ae0kO17qEuTjsqeyYMRPSUDacIKIquws2Y6KjmxAyNx8xB3xQbw==",
-      "dependencies": {
         "@types/node": "*"
       }
     },
@@ -3800,9 +3815,9 @@
       }
     },
     "node_modules/@types/eslint": {
-      "version": "8.56.0",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.0.tgz",
-      "integrity": "sha512-FlsN0p4FhuYRjIxpbdXovvHQhtlG05O1GG/RNWvdAxTboR438IOTwmrY/vLA+Xfgg06BTkP045M3vpFwTMv1dg==",
+      "version": "8.44.8",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.44.8.tgz",
+      "integrity": "sha512-4K8GavROwhrYl2QXDXm0Rv9epkA8GBFu0EI+XrrnnuCl7u8CWBRusX7fXJfanhZTDWSAL24gDI/UqXyUM0Injw==",
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -4027,11 +4042,6 @@
       "version": "2.4.4",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
       "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA=="
-    },
-    "node_modules/@types/object-path": {
-      "version": "0.11.4",
-      "resolved": "https://registry.npmjs.org/@types/object-path/-/object-path-0.11.4.tgz",
-      "integrity": "sha512-4tgJ1Z3elF/tOMpA8JLVuR9spt9Ynsf7+JjqsQ2IqtiPJtcLoHoXcT6qU4E10cPFqyXX5HDm9QwIzZhBSkLxsw=="
     },
     "node_modules/@types/parse-json": {
       "version": "4.0.1",
@@ -4388,9 +4398,9 @@
       }
     },
     "node_modules/acorn-walk": {
-      "version": "8.3.1",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.1.tgz",
-      "integrity": "sha512-TgUZgYvqZprrl7YldZNoa9OciCAyZR+Ejm9eXzKCmjsF5IKp/wgQ7Z/ZpjpGTIUPwrHQIcYeI8qDh4PsEwxMbw==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.0.tgz",
+      "integrity": "sha512-FS7hV565M5l1R08MXqo8odwMTB02C2UqzB17RVgu9EyuYFBqJZ3/ZY97sQD5FewVu1UyDFc1yztUDrAwT0EypA==",
       "engines": {
         "node": ">=0.4.0"
       }
@@ -5276,14 +5286,14 @@
       }
     },
     "node_modules/busboy": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
-      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-0.3.1.tgz",
+      "integrity": "sha512-y7tTxhGKXcyBxRKAni+awqx8uqaJKrSFSNFSeRG5CsWNdmy2BIK+6VGWEW7TZnIO/533mtMEA4rOevQV815YJw==",
       "dependencies": {
-        "streamsearch": "^1.1.0"
+        "dicer": "0.3.0"
       },
       "engines": {
-        "node": ">=10.16.0"
+        "node": ">=4.5.0"
       }
     },
     "node_modules/byte-size": {
@@ -6032,9 +6042,9 @@
       }
     },
     "node_modules/core-js-pure": {
-      "version": "3.34.0",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.34.0.tgz",
-      "integrity": "sha512-pmhivkYXkymswFfbXsANmBAewXx86UBfmagP+w0wkK06kLsLlTK5oQmsURPivzMkIBQiYq2cjamcZExIwlFQIg==",
+      "version": "3.33.3",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.33.3.tgz",
+      "integrity": "sha512-taJ00IDOP+XYQEA2dAe4ESkmHt1fL8wzYDo3mRWQey8uO9UojlBFMneA65kMyxfYP7106c6LzWaq7/haDT6BCQ==",
       "hasInstallScript": true,
       "funding": {
         "type": "opencollective",
@@ -6394,9 +6404,9 @@
       }
     },
     "node_modules/default-browser/node_modules/npm-run-path": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.2.0.tgz",
-      "integrity": "sha512-W4/tgAXFqFA0iL7fk0+uQ3g7wkL8xJmx3XdK0VGb4cHW//eZTtKGvFBBoRKVTpY7n6ze4NL9ly7rgXcHufqXKg==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.1.0.tgz",
+      "integrity": "sha512-sJOdmRGrY2sjNTRMbSvluQqg+8X7ZK61yvzBEIDhz4f8z1TZFYABsqjjCBd/0PUNE9M6QDgHJXQkGUEm7Q+l9Q==",
       "dependencies": {
         "path-key": "^4.0.0"
       },
@@ -6614,6 +6624,17 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
       "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="
+    },
+    "node_modules/dicer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/dicer/-/dicer-0.3.0.tgz",
+      "integrity": "sha512-MdceRRWqltEG2dZqO769g27N/3PXfcKl04VhYnBlo2YhH7zPi88VebsjTKclaOyiuMaGU72hTfw3VkUitGcVCA==",
+      "dependencies": {
+        "streamsearch": "0.1.2"
+      },
+      "engines": {
+        "node": ">=4.5.0"
+      }
     },
     "node_modules/dir-glob": {
       "version": "3.0.1",
@@ -7607,9 +7628,9 @@
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
     },
     "node_modules/fastq": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.16.0.tgz",
-      "integrity": "sha512-ifCoaXsDrsdkWTtiNJX5uzHDsrck5TzfKKDcuFFTIrrc/BS076qgEIfoIy1VeZqViznfKiysPYTh/QeHtnIsYA==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
+      "integrity": "sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==",
       "dependencies": {
         "reusify": "^1.0.4"
       }
@@ -8498,12 +8519,11 @@
       }
     },
     "node_modules/graphql": {
-      "version": "16.8.1",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.8.1.tgz",
-      "integrity": "sha512-59LZHPdGZVh695Ud9lRzPBVTtlX9ZCV150Er2W43ro37wVof0ctenSaskPPjN7lVTIN8mSZt8PHUNKZuNQUuxw==",
-      "peer": true,
+      "version": "15.8.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.8.0.tgz",
+      "integrity": "sha512-5gghUc24tP9HRznNpV2+FIoq3xKkj5dTQqf4v0CpdPbFVwFkWoxOM+o+2OC9ZSvjEMTjfmG9QT+gcvggTwW1zw==",
       "engines": {
-        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+        "node": ">= 10.x"
       }
     },
     "node_modules/graphql-depth-limit": {
@@ -8578,59 +8598,23 @@
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/graphql-upload": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/graphql-upload/-/graphql-upload-15.0.2.tgz",
-      "integrity": "sha512-ufJAkZJBKWRDD/4wJR3VZMy9QWTwqIYIciPtCEF5fCNgWF+V1p7uIgz+bP2YYLiS4OJBhCKR8rnqE/Wg3XPUiw==",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/graphql-upload/-/graphql-upload-13.0.0.tgz",
+      "integrity": "sha512-YKhx8m/uOtKu4Y1UzBFJhbBGJTlk7k4CydlUUiNrtxnwZv0WigbRHP+DVhRNKt7u7DXOtcKZeYJlGtnMXvreXA==",
       "dependencies": {
-        "@types/busboy": "^1.5.0",
-        "@types/node": "*",
-        "@types/object-path": "^0.11.1",
-        "busboy": "^1.6.0",
+        "busboy": "^0.3.1",
         "fs-capacitor": "^6.2.0",
-        "http-errors": "^2.0.0",
+        "http-errors": "^1.8.1",
         "object-path": "^0.11.8"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.0.0 || >= 18.0.0"
+        "node": "^12.22.0 || ^14.17.0 || >= 16.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/jaydenseric"
       },
       "peerDependencies": {
-        "@types/express": "^4.0.29",
-        "@types/koa": "^2.11.4",
-        "graphql": "^16.3.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/express": {
-          "optional": true
-        },
-        "@types/koa": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/graphql-upload/node_modules/depd": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
-      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/graphql-upload/node_modules/http-errors": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
-      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
-      "dependencies": {
-        "depd": "2.0.0",
-        "inherits": "2.0.4",
-        "setprototypeof": "1.2.0",
-        "statuses": "2.0.1",
-        "toidentifier": "1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.8"
+        "graphql": "0.13.1 - 16"
       }
     },
     "node_modules/gzip-size": {
@@ -10857,9 +10841,9 @@
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
     },
     "node_modules/mrmime": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.0.tgz",
-      "integrity": "sha512-eu38+hdgojoyq63s+yTpN4XMBdt5l8HhMhc4VKLO9KM5caLIBvUm4thi7fFaxyTmCKeNnXZ5pAlBwCUnhA09uw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-1.0.1.tgz",
+      "integrity": "sha512-hzzEagAgDyoU1Q6yg5uI+AorQgdvMCur3FcKf7NhMKWsaYg+RnbTyHRa/9IlLF9rf455MOCtcqqrQQ83pPP7Uw==",
       "engines": {
         "node": ">=10"
       }
@@ -12228,9 +12212,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.32",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.32.tgz",
-      "integrity": "sha512-D/kj5JNu6oo2EIy+XL/26JEDTlIbB8hw85G8StOE6L74RQAVVP5rej6wxCNqyMbR4RkPfqvezVbPw81Ngd6Kcw==",
+      "version": "8.4.31",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
+      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -12246,7 +12230,7 @@
         }
       ],
       "dependencies": {
-        "nanoid": "^3.3.7",
+        "nanoid": "^3.3.6",
         "picocolors": "^1.0.0",
         "source-map-js": "^1.0.2"
       },
@@ -12282,9 +12266,9 @@
       }
     },
     "node_modules/postcss-modules-scope": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-3.1.0.tgz",
-      "integrity": "sha512-SaIbK8XW+MZbd0xHPf7kdfA/3eOt7vxJ72IRecn3EzuZVLr1r0orzf0MX/pN8m+NMDoo6X/SQd8oeKqGZd8PXg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-3.0.0.tgz",
+      "integrity": "sha512-hncihwFA2yPath8oZ15PZqvWGkWf+XUfQgUGamS4LqoP1anQLOsOJw0vr7J7IwLpoY9fatA2qiGUGmuZL0Iqlg==",
       "dependencies": {
         "postcss-selector-parser": "^6.0.4"
       },
@@ -13966,12 +13950,12 @@
       "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
     },
     "node_modules/sirv": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/sirv/-/sirv-2.0.4.tgz",
-      "integrity": "sha512-94Bdh3cC2PKrbgSOUqTiGPWVZeSiXfKOVZNJniWoqrWrRkB1CJzBU3NEbiTsPcYy1lDsANA/THzS+9WBiy5nfQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/sirv/-/sirv-2.0.3.tgz",
+      "integrity": "sha512-O9jm9BsID1P+0HOi81VpXPoDxYP374pkOLzACAoyUQ/3OUVndNpsz6wMnY2z+yOxzbllCKZrM+9QrWsv4THnyA==",
       "dependencies": {
-        "@polka/url": "^1.0.0-next.24",
-        "mrmime": "^2.0.0",
+        "@polka/url": "^1.0.0-next.20",
+        "mrmime": "^1.0.0",
         "totalist": "^3.0.0"
       },
       "engines": {
@@ -14410,17 +14394,17 @@
       "integrity": "sha512-QzQxpoacatkreL6jsxnVb7X5R/pGw9OUv2qWTYWnmLpg4NdN31snPy/f3TdQE1ZUXaThRvj1Zw4/OGg0ZkaLMA=="
     },
     "node_modules/streamsearch": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
-      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
+      "integrity": "sha512-jos8u++JKm0ARcSUTAZXOVC0mSox7Bhn6sBgty73P1f3JGf7yG2clTbBNHUdde/kdvP2FESam+vM6l8jBrNxHA==",
       "engines": {
-        "node": ">=10.0.0"
+        "node": ">=0.8.0"
       }
     },
     "node_modules/streamx": {
-      "version": "2.15.6",
-      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.15.6.tgz",
-      "integrity": "sha512-q+vQL4AAz+FdfT137VF69Cc/APqUbxy+MDOImRrMvchJpigHj9GksgDU2LYbO9rx7RX6osWgxJB2WxhYv4SZAw==",
+      "version": "2.15.5",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.15.5.tgz",
+      "integrity": "sha512-9thPGMkKC2GctCzyCUjME3yR03x2xNo0GPKGkRw2UMYN+gqWa9uqpyNWhmsNCutU5zHmkUum0LsCRQTXUgUCAg==",
       "dependencies": {
         "fast-fifo": "^1.1.0",
         "queue-tick": "^1.0.1"
@@ -14508,13 +14492,13 @@
       "integrity": "sha512-Ca5ib8HrFn+f+0n4N4ScTIA9iTOQ7MaGS1ylHcoVqW9J7w2w8PzN6g9gKmTYgGEBH8e120+RCmhpje6jC5uGWA=="
     },
     "node_modules/styled-components": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.3.3.tgz",
-      "integrity": "sha512-++4iHwBM7ZN+x6DtPPWkCI4vdtwumQ+inA/DdAsqYd4SVgUKJie5vXyzotA00ttcFdQkCng7zc6grwlfIfw+lw==",
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.3.11.tgz",
+      "integrity": "sha512-uuzIIfnVkagcVHv9nE0VPlHPSCmXIUGKfJ42LNjxCCTDTL5sgnJ8Z7GZBq0EnLYGln77tPpEpExt2+qa+cZqSw==",
       "dependencies": {
         "@babel/helper-module-imports": "^7.0.0",
         "@babel/traverse": "^7.4.5",
-        "@emotion/is-prop-valid": "^0.8.8",
+        "@emotion/is-prop-valid": "^1.1.0",
         "@emotion/stylis": "^0.8.4",
         "@emotion/unitless": "^0.7.4",
         "babel-plugin-styled-components": ">= 1.12.0",
@@ -14706,9 +14690,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.26.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.26.0.tgz",
-      "integrity": "sha512-dytTGoE2oHgbNV9nTzgBEPaqAWvcJNl66VZ0BkJqlvp71IjO8CxdBx/ykCNb47cLnCmCvRZ6ZR0tLkqvZCdVBQ==",
+      "version": "5.24.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.24.0.tgz",
+      "integrity": "sha512-ZpGR4Hy3+wBEzVEnHvstMvqpD/nABNelQn/z2r0fjVWGQsN3bpOLzQlqDxmb4CDZnXq5lpjnQ+mHQLAOpfM5iw==",
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.8.2",

--- a/cockpit-api/package.json
+++ b/cockpit-api/package.json
@@ -10,10 +10,10 @@
     "strapi": "strapi"
   },
   "dependencies": {
-    "@strapi/plugin-graphql": "^4.16.2",
-    "@strapi/plugin-i18n": "4.16.2",
-    "@strapi/plugin-users-permissions": "4.16.2",
-    "@strapi/strapi": "4.16.2",
+    "@strapi/plugin-graphql": "^4.15.5",
+    "@strapi/plugin-i18n": "4.15.5",
+    "@strapi/plugin-users-permissions": "4.15.5",
+    "@strapi/strapi": "4.15.5",
     "better-sqlite3": "9.2.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",


### PR DESCRIPTION
Reverts ncs-northware/northware-cockpit#51

Mit `strapi@4.16.2` kann strapi wegen einem Bug im GraphQL Plugin nicht starten.

Dieser Issue beschreibt genaueres:
https://github.com/ncs-northware/northware-development/issues/47